### PR TITLE
Add delete and upload tasks to flow.

### DIFF
--- a/pipeline/matching_pipeline.py
+++ b/pipeline/matching_pipeline.py
@@ -3,6 +3,7 @@ import sys
 sys.path.append("./")
 
 import dataclasses
+import datetime
 import json
 import os
 import pandas as pd
@@ -18,7 +19,14 @@ from pipeline.matching import (
     get_matches,
     validate_matches,
 )
-from pipeline.utils.matches import generate_keys, from_release_tag
+from pipeline.utils.matches import (
+    generate_keys,
+    from_release_tag,
+    to_release_tag,
+)
+
+
+MS = 1000
 
 
 @task
@@ -140,11 +148,109 @@ def compute_matches(
     return df_matches
 
 
+@task
+def delete_previous_release(
+    db, community: str, release_tag: str, force: bool = False
+):
+    logger = prefect.context.get("logger")
+    release = from_release_tag(release_tag)
+    if force:
+        logger.info("Proceeding with forced deletion.")
+    elif release < datetime.datetime.now():
+        logger.warning(
+            (
+                "You are trying to delete a past round of matches.\n"
+                "Are you sure?\n"
+                "This will also delete any chats from those matches.\n"
+                "Use the `force` parameter to run this deletion."
+            )
+        )
+        return
+
+    # Get user-match records for the given community and release
+    matches_ref = db.reference(f"matches/{community}")
+    release_tag = to_release_tag(release)
+    query = matches_ref.order_by_child("release_tag").equal_to(release_tag)
+    match_records = query.get()
+    logger.info(f"Found {len(match_records)} user-match records to remove.")
+
+    # Add chat messages from those matches to the removal set
+    deleted_chats = {}
+    for match in match_records.values():
+        deleted_chats[match["id"]] = None
+
+    # Only remove if records are found, otherwise, we might accidentally
+    # delete all match user-records!
+    if match_records:
+        deleted_matches = {key: None for key in match_records}
+        matches_ref.update(deleted_matches)
+        logger.info(f"Removed {len(deleted_matches)} user-match records.")
+    else:
+        logger.info("No user-match records to remove.")
+
+    if deleted_chats:
+        chats_ref = db.reference(f"messages/{community}")
+        chats_ref.update(deleted_chats)
+        logger.info(f"Removed messages for {len(deleted_chats)} chats.")
+    else:
+        logger.info("No chat message records to remove.")
+
+
+@task
+def upload_matches(
+    db,
+    df_matches: pd.DataFrame,
+    community: str,
+    release_tag: str,
+    force: bool = False,
+):
+    logger = prefect.context.get("logger")
+    # Read matches into dataclass values
+    logger.info("Read {} rows, {} cols.".format(*df_matches.shape))
+    df_matches["release"] = df_matches["release"].apply(from_release_tag)
+    match_dicts = df_matches.to_dict(orient="records")
+    matches = [Match(**m) for m in match_dicts]
+
+    # Build match records for each user
+    res = {}
+    for m in matches:
+        release_tag = to_release_tag(m.release)
+        release_ts = m.release.timestamp() * MS
+        participants = {other_uid: True for other_uid in m.users}
+        match_id = f"{release_tag}~{m.key}"
+        for my_uid in m.users:
+            combo_id = f"{match_id}~{my_uid}"
+            path = f"{m.community}/{combo_id}"
+            record = {
+                "for": my_uid,
+                "participants": participants,
+                "release_tag": release_tag,
+                "release_timestamp": release_ts,
+                "title": m.title,
+                "id": match_id,
+            }
+            res[path] = record
+    logger.info(f"Generated {len(res)} user-match records.")
+
+    # Write matches to Firebase, if intended
+    if not force:
+        logger.warning(
+            (
+                "Dry run: Skipped writing records to Firebase.\n"
+                "Use the `force` parameter to apply this action."
+            )
+        )
+        return
+    matches_ref = db.reference("matches")
+    matches_ref.update(res)
+
+
 def matching_pipeline() -> Flow:
     with Flow(name="matching_pipeline") as flow:
         param_community = Parameter(name="community", required=True)
         param_matching_retries = Parameter(name="matching_retries", default=5)
         param_release = Parameter(name="release", required=True)
+        param_force = Parameter(name="force", required=False)
 
         secret_database_url = PrefectSecret("database_url")
         secret_admin_credentials = PrefectSecret("admin_credentials")
@@ -161,6 +267,18 @@ def matching_pipeline() -> Flow:
             param_release,
             param_matching_retries,
         )
+
+        # Do not attempt deletion until new matches are ready
+        deleted = delete_previous_release(
+            db, param_community, param_release, param_force
+        )
+        deleted.set_upstream(df_matches)
+
+        # Do not attempt upload until previous release deletion resolved
+        uploaded = upload_matches(
+            db, df_matches, param_community, param_release, param_force
+        )
+        uploaded.set_upstream(deleted)
 
     return flow
 

--- a/run.sh
+++ b/run.sh
@@ -102,6 +102,12 @@ elif [ "$1" == "prefect-agent" ]; then
   # Starter local agent, necessary for executing flows
   prefect agent local start
 
+elif [ "$1" == "prefect-register" ]; then
+  # Register latest version of flows with Prefect Server
+  source .venv/bin/activate
+  prefect create project butterfly
+  python3 pipeline/register_all_flows.py
+
 else
   echo "No run shortcut found for: $1"
   echo "Did you pull the latest version?"


### PR DESCRIPTION
## Summary

- Move remaining tasks from demo pipeline script to Prefect flow
- Move delete previous release and upload matches to flow tasks
- Protect database actions using the `force` parameter
- Verify that flow works locally and from Prefect Server
- Add run shortcut to register latest Prefect flows

## Usage

Whenever you change your flows, you must register the latest version in order to trigger a run from the Prefect dashboard. This is not necessary when running locally.

```bash
run prefect-register
```