### PR TITLE
Pull chat header out of chat app.

### DIFF
--- a/frontend/src/pages/ChatPage.jsx
+++ b/frontend/src/pages/ChatPage.jsx
@@ -1,10 +1,12 @@
-import React from 'react'
+import React, { useContext } from 'react'
 import { Link, useParams } from 'react-router-dom'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faXmarkCircle } from '@fortawesome/free-solid-svg-icons'
 
-import { ChatApp } from '../common/components/Chat'
+import { ChatApp, ChatContext } from '../common/components/Chat'
+import { UserTile } from '../common/components/User'
 import { COMMUNITY } from '../common/utils/constants'
+import { formatMatchDate } from '../common/utils/datetime'
 
 import '../styles/Chats.css'
 
@@ -19,6 +21,22 @@ function BackToChatsButton() {
     )
 }
 
+function ChatHeader() {
+    const chat = useContext(ChatContext)
+    const userEls = Object.values(chat?.participants || {}).map((user) => (
+        <UserTile key={user.uid} user={user} />
+    ))
+    const matchDate = formatMatchDate(chat?.release_timestamp)
+    return (
+        <>
+            <h1>Butterfly Chat</h1>
+            <p>Messages will disappear after 30 days.</p>
+            <p>Your match for the week of {matchDate}.</p>
+            <div className="UserRowCentered">{userEls}</div>
+        </>
+    )
+}
+
 export default function ChatPage() {
     const { chatId } = useParams()
     const fullChatId = `${COMMUNITY}/${chatId}`
@@ -26,7 +44,7 @@ export default function ChatPage() {
         <div className="ChatPage">
             <div className="ChatContainer">
                 <BackToChatsButton />
-                <ChatApp chatId={fullChatId} />
+                <ChatApp chatId={fullChatId} header={<ChatHeader />} />
             </div>
         </div>
     )


### PR DESCRIPTION
## Summary

First part of #29.

Allows the chat header to be customized separately from the `ChatApp` component and then passed in as a prop. Uses the [React Context](https://reactjs.org/docs/context.html) feature to enable the custom chat header component to access the chat data.

Will do the chat body in a separate PR so that this example is easier to understand.