### PR TITLE
Pull the remaining chat app components out of the wrapper.

### DIFF
--- a/frontend/src/common/components/Chat.jsx
+++ b/frontend/src/common/components/Chat.jsx
@@ -1,13 +1,9 @@
-import React, { createRef, createContext, useMemo } from 'react'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faArrowRight } from '@fortawesome/free-solid-svg-icons'
+import React, { createContext, useMemo } from 'react'
 
 import { useCurrentAuthUser } from '../utils/auth'
 import { useGetChatData, useGetMessages, sendMessage } from '../utils/chat'
 import { MESSAGE_TYPE, UNKNOWN_USER } from '../utils/constants'
 import { Error } from './Errors'
-
-export const ChatContext = createContext()
 
 function getAuthorClasses(participants, myUserId) {
     return Object.keys(participants)
@@ -42,29 +38,6 @@ export function Message({ data, myUserId, participants }) {
     )
 }
 
-function ChatComposer({ chatId, myUserId }) {
-    const textRef = createRef()
-
-    const doSend = () => {
-        const message = textRef.current.value
-        if (!myUserId || !message) return
-        sendMessage(chatId, {
-            message,
-            from: myUserId,
-        })
-        textRef.current.value = ''
-    }
-
-    return (
-        <div className="ChatComposer">
-            <textarea ref={textRef} className="Input" />
-            <button type="button" onClick={doSend} className="Button Send">
-                <FontAwesomeIcon icon={faArrowRight} className="IconBefore" />
-            </button>
-        </div>
-    )
-}
-
 function ChatLoading() {
     return <p className="Centered">Loading chat...</p>
 }
@@ -83,22 +56,33 @@ function getChatDisplayError(chatId, chat, myUserId) {
     return null
 }
 
-export function ChatApp({ chatId, header, conversation }) {
+export const ChatContext = createContext()
+
+export function ChatApp({ chatId, header, conversation, composer }) {
     const authUser = useCurrentAuthUser()
     const myUserId = authUser?.uid
     const chat = useGetChatData(`${chatId}~${myUserId}`)
     const messages = useGetMessages(chatId)
-    const chatMemo = useMemo(() => ({ chat, messages, myUserId }))
 
     const displayError = getChatDisplayError(chatId, chat, myUserId)
     const isReady = chat.isLoaded && !displayError
+
+    const sendChatMessage = (message) => {
+        if (!myUserId || !message) return
+        sendMessage(chatId, {
+            message,
+            from: myUserId,
+        })
+    }
+
+    const chatMemo = useMemo(() => ({ chat, messages, myUserId, sendChatMessage }))
 
     const chatAppEl = (
         <ChatContext.Provider value={chatMemo}>
             <div className="ChatAppInner HideScroll">
                 <div className="ChatHeader">{header}</div>
                 <div className="ChatMessages">{conversation}</div>
-                <ChatComposer chatId={chatId} myUserId={myUserId} />
+                <div className="ChatComposer">{composer}</div>
             </div>
         </ChatContext.Provider>
     )

--- a/frontend/src/common/components/Chat.jsx
+++ b/frontend/src/common/components/Chat.jsx
@@ -1,4 +1,4 @@
-import React, { createRef, createContext } from 'react'
+import React, { createRef, createContext, useMemo } from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faArrowRight } from '@fortawesome/free-solid-svg-icons'
 
@@ -42,21 +42,6 @@ export function Message({ data, myUserId, participants }) {
     )
 }
 
-function ChatMessages({ chatId, chat, myUserId }) {
-    const messages = useGetMessages(chatId)
-    const isLoaded = chat.isLoaded && messages.length > 0
-
-    const messageEls =
-        isLoaded &&
-        messages.map((m) => (
-            <Message key={m.key} data={m} myUserId={myUserId} participants={chat.participants} />
-        ))
-
-    const loadingEl = <p>No messages yet... Will you start things off?</p>
-
-    return <div className="ChatMessages">{isLoaded ? messageEls : loadingEl}</div>
-}
-
 function ChatComposer({ chatId, myUserId }) {
     const textRef = createRef()
 
@@ -80,10 +65,6 @@ function ChatComposer({ chatId, myUserId }) {
     )
 }
 
-function ChatHeaderWrapper({ header }) {
-    return <div className="ChatHeader">{header}</div>
-}
-
 function ChatLoading() {
     return <p className="Centered">Loading chat...</p>
 }
@@ -102,19 +83,21 @@ function getChatDisplayError(chatId, chat, myUserId) {
     return null
 }
 
-export function ChatApp({ chatId, header }) {
+export function ChatApp({ chatId, header, conversation }) {
     const authUser = useCurrentAuthUser()
     const myUserId = authUser?.uid
     const chat = useGetChatData(`${chatId}~${myUserId}`)
+    const messages = useGetMessages(chatId)
+    const chatMemo = useMemo(() => ({ chat, messages, myUserId }))
 
     const displayError = getChatDisplayError(chatId, chat, myUserId)
     const isReady = chat.isLoaded && !displayError
 
     const chatAppEl = (
-        <ChatContext.Provider value={chat}>
+        <ChatContext.Provider value={chatMemo}>
             <div className="ChatAppInner HideScroll">
-                <ChatHeaderWrapper header={header} />
-                <ChatMessages chatId={chatId} myUserId={myUserId} chat={chat} />
+                <div className="ChatHeader">{header}</div>
+                <div className="ChatMessages">{conversation}</div>
                 <ChatComposer chatId={chatId} myUserId={myUserId} />
             </div>
         </ChatContext.Provider>

--- a/frontend/src/common/components/Chat.jsx
+++ b/frontend/src/common/components/Chat.jsx
@@ -75,7 +75,12 @@ export function ChatApp({ chatId, header, conversation, composer }) {
         })
     }
 
-    const chatMemo = useMemo(() => ({ chat, messages, myUserId, sendChatMessage }))
+    const chatMemo = useMemo(() => ({
+        chat,
+        messages,
+        myUserId,
+        sendChatMessage,
+    }))
 
     const chatAppEl = (
         <ChatContext.Provider value={chatMemo}>

--- a/frontend/src/pages/ChatPage.jsx
+++ b/frontend/src/pages/ChatPage.jsx
@@ -1,7 +1,7 @@
-import React, { useContext } from 'react'
+import React, { createRef, useContext } from 'react'
 import { Link, useParams } from 'react-router-dom'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faXmarkCircle } from '@fortawesome/free-solid-svg-icons'
+import { faArrowRight, faXmarkCircle } from '@fortawesome/free-solid-svg-icons'
 
 import { ChatApp, ChatContext, Message } from '../common/components/Chat'
 import { UserTile } from '../common/components/User'
@@ -51,6 +51,25 @@ function ChatConversation() {
     return isLoaded ? messageEls : loadingEl
 }
 
+function ChatComposer() {
+    const textRef = createRef()
+    const { sendChatMessage } = useContext(ChatContext)
+
+    const doSend = () => {
+        sendChatMessage(textRef.current.value)
+        textRef.current.value = ''
+    }
+
+    return (
+        <>
+            <textarea ref={textRef} className="Input" />
+            <button type="button" onClick={doSend} className="Button Send">
+                <FontAwesomeIcon icon={faArrowRight} className="IconBefore" />
+            </button>
+        </>
+    )
+}
+
 export default function ChatPage() {
     const { chatId } = useParams()
     const fullChatId = `${COMMUNITY}/${chatId}`
@@ -62,6 +81,7 @@ export default function ChatPage() {
                     chatId={fullChatId}
                     header={<ChatHeader />}
                     conversation={<ChatConversation />}
+                    composer={<ChatComposer />}
                 />
             </div>
         </div>

--- a/frontend/src/pages/ChatPage.jsx
+++ b/frontend/src/pages/ChatPage.jsx
@@ -3,7 +3,7 @@ import { Link, useParams } from 'react-router-dom'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faXmarkCircle } from '@fortawesome/free-solid-svg-icons'
 
-import { ChatApp, ChatContext } from '../common/components/Chat'
+import { ChatApp, ChatContext, Message } from '../common/components/Chat'
 import { UserTile } from '../common/components/User'
 import { COMMUNITY } from '../common/utils/constants'
 import { formatMatchDate } from '../common/utils/datetime'
@@ -22,7 +22,7 @@ function BackToChatsButton() {
 }
 
 function ChatHeader() {
-    const chat = useContext(ChatContext)
+    const { chat } = useContext(ChatContext)
     const userEls = Object.values(chat?.participants || {}).map((user) => (
         <UserTile key={user.uid} user={user} />
     ))
@@ -37,6 +37,20 @@ function ChatHeader() {
     )
 }
 
+function ChatConversation() {
+    const { chat, messages, myUserId } = useContext(ChatContext)
+
+    const isLoaded = chat.isLoaded && messages.length > 0
+    const messageEls =
+        isLoaded &&
+        messages.map((m) => (
+            <Message key={m.key} data={m} myUserId={myUserId} participants={chat.participants} />
+        ))
+    const loadingEl = <p>No messages yet... Will you start things off?</p>
+
+    return isLoaded ? messageEls : loadingEl
+}
+
 export default function ChatPage() {
     const { chatId } = useParams()
     const fullChatId = `${COMMUNITY}/${chatId}`
@@ -44,7 +58,11 @@ export default function ChatPage() {
         <div className="ChatPage">
             <div className="ChatContainer">
                 <BackToChatsButton />
-                <ChatApp chatId={fullChatId} header={<ChatHeader />} />
+                <ChatApp
+                    chatId={fullChatId}
+                    header={<ChatHeader />}
+                    conversation={<ChatConversation />}
+                />
             </div>
         </div>
     )


### PR DESCRIPTION
## Summary

Finishes #29, follow-up to #33.

- Pull chat conversation out of chat app
- Pull chat composer out of chat app
- Remove wrapper components to show chat app JSX in one place
- Add `messages` and `sendChatMessage()` to `ChatContext`
- Apply `useMemo` to `ChatContext` to avoid unnecessary cloning
- Decided to leave the placeholder chat loading component inside chat app, as it is reasonably common, we can separate it out later if we need to