### PR TITLE
Move load tasks into module.

### DIFF
--- a/pipeline/extract/matches_test.py
+++ b/pipeline/extract/matches_test.py
@@ -1,11 +1,10 @@
 import pandas as pd
-from firebase_admin import db
 from unittest.mock import MagicMock
 from pipeline.extract.matches import extract_recent_matches
 
 
 def test_extract_recent_matches_converts_user_match_records_to_match_records():
-    # Mock database call so that test does actually query a database
+    # Mock database call so that test does not actually query a database
     default_expected = {"title": None}
     matches = {
         "1~A": {

--- a/pipeline/extract/users_test.py
+++ b/pipeline/extract/users_test.py
@@ -1,10 +1,9 @@
-from firebase_admin import db
 from unittest.mock import MagicMock
 from pipeline.extract.users import extract_users
 
 
 def test_extract_users_excludes_users_with_null_latest_login():
-    # Mock database call so that test does actually query a database
+    # Mock database call so that test does not actually query a database
     users = {
         "1": {"uid": "1"},
         "2": {"uid": "2", "latestLogin": 100},

--- a/pipeline/load/release.py
+++ b/pipeline/load/release.py
@@ -1,0 +1,105 @@
+import datetime
+import pandas as pd
+import prefect
+from prefect import task
+from pipeline.schema.match import Match
+from pipeline.utils.constants import MS
+from pipeline.utils.release import from_release_tag, to_release_tag
+
+
+@task
+def delete_previous_release(
+    db, community: str, release_tag: str, force: bool = False
+):
+    logger = prefect.context.get("logger")
+    release = from_release_tag(release_tag)
+    if force:
+        logger.info("Proceeding with forced deletion.")
+    elif release < datetime.datetime.now():
+        logger.warning(
+            (
+                "You are trying to delete a past round of matches.\n"
+                "Are you sure?\n"
+                "This will also delete any chats from those matches.\n"
+                "Skipped deleting records.\n"
+                "Use the `force` parameter to run this deletion."
+            )
+        )
+        return
+
+    # Get user-match records for the given community and release
+    matches_ref = db.reference(f"matches/{community}")
+    release_tag = to_release_tag(release)
+    query = matches_ref.order_by_child("release_tag").equal_to(release_tag)
+    match_records = query.get()
+    logger.info(f"Found {len(match_records)} user-match records to remove.")
+
+    # Add chat messages from those matches to the removal set
+    deleted_chats = {}
+    for match in match_records.values():
+        deleted_chats[match["id"]] = None
+
+    # Only remove if records are found, otherwise, we might accidentally
+    # delete all match user-records!
+    if match_records:
+        deleted_matches = {key: None for key in match_records}
+        matches_ref.update(deleted_matches)
+        logger.info(f"Removed {len(deleted_matches)} user-match records.")
+    else:
+        logger.info("No user-match records to remove.")
+
+    if deleted_chats:
+        chats_ref = db.reference(f"messages/{community}")
+        chats_ref.update(deleted_chats)
+        logger.info(f"Removed messages for {len(deleted_chats)} chats.")
+    else:
+        logger.info("No chat message records to remove.")
+
+
+@task
+def upload_matches(
+    db,
+    df_matches: pd.DataFrame,
+    community: str,
+    release_tag: str,
+    force: bool = False,
+):
+    logger = prefect.context.get("logger")
+    # Read matches into dataclass values
+    logger.info("Read {} rows, {} cols.".format(*df_matches.shape))
+    df_matches["release"] = df_matches["release"].apply(from_release_tag)
+    match_dicts = df_matches.to_dict(orient="records")
+    matches = [Match(**m) for m in match_dicts]
+
+    # Build match records for each user
+    res = {}
+    for m in matches:
+        release_tag = to_release_tag(m.release)
+        release_ts = m.release.timestamp() * MS
+        participants = {other_uid: True for other_uid in m.users}
+        match_id = f"{release_tag}~{m.key}"
+        for my_uid in m.users:
+            combo_id = f"{match_id}~{my_uid}"
+            path = f"{m.community}/{combo_id}"
+            record = {
+                "for": my_uid,
+                "participants": participants,
+                "release_tag": release_tag,
+                "release_timestamp": release_ts,
+                "title": m.title,
+                "id": match_id,
+            }
+            res[path] = record
+    logger.info(f"Generated {len(res)} user-match records.")
+
+    # Write matches to Firebase, if intended
+    if not force:
+        logger.warning(
+            (
+                "Dry run: Skipped writing records to Firebase.\n"
+                "Use the `force` parameter to apply this action."
+            )
+        )
+        return
+    matches_ref = db.reference("matches")
+    matches_ref.update(res)

--- a/pipeline/load/release_test.py
+++ b/pipeline/load/release_test.py
@@ -1,0 +1,246 @@
+import datetime
+import pandas as pd
+from unittest.mock import MagicMock
+from pipeline.load.release import delete_previous_release, upload_matches
+
+
+MS = 1000
+TS_2022_04_01 = datetime.datetime(2022, 4, 1).timestamp() * MS
+DT_2022_03_31 = datetime.datetime(2022, 3, 31)
+DT_2022_04_02 = datetime.datetime(2022, 4, 2)
+
+
+def test_upload_matches_per_user_for_current_release():
+    # Mock database call so that test does not actually query a database
+    mock_update_matches = MagicMock()
+    mock_db = MagicMock()
+    mock_db.reference("matches").update = mock_update_matches
+
+    default_match = {"title": None, "community": "test"}
+    matches = [
+        {
+            **default_match,
+            "key": "1",
+            "release": "2022-04-01",
+            "users": {"A", "B"},
+        },
+        {
+            **default_match,
+            "key": "2",
+            "release": "2022-04-07",
+            "users": {"C", "D"},
+        },
+    ]
+
+    # Run Prefect task with mock
+    upload_matches.run(
+        mock_db,
+        pd.DataFrame(matches),
+        community="test",
+        load_release_tag="2022-04-01",
+        force=True,
+    )
+
+    # Verify that output contains one record per user per match
+    # Verify that output skips records with a different release tag from the run
+    expected = {
+        "test/2022-04-01~1~A": {
+            "id": "2022-04-01~1",
+            "for": "A",
+            "participants": {"A": True, "B": True},
+            "release_tag": "2022-04-01",
+            "release_timestamp": TS_2022_04_01,
+            "title": None,
+        },
+        "test/2022-04-01~1~B": {
+            "id": "2022-04-01~1",
+            "for": "B",
+            "participants": {"A": True, "B": True},
+            "release_tag": "2022-04-01",
+            "release_timestamp": TS_2022_04_01,
+            "title": None,
+        },
+    }
+    # Verify that the expected data was sent to the database
+    mock_update_matches.assert_called_once_with(expected)
+
+
+def test_upload_matches_skip_without_force():
+    # Mock database call so that test does not actually query a database
+    mock_db = MagicMock()
+
+    # Prepare inputs for task
+    matches = [
+        {
+            "title": None,
+            "community": "test",
+            "key": "1",
+            "release": "2022-04-01",
+            "users": {"A", "B"},
+        },
+    ]
+
+    # Run Prefect task with mock
+    upload_matches.run(
+        mock_db,
+        pd.DataFrame(matches),
+        community="test",
+        load_release_tag="2022-04-01",
+    )
+
+    # Verify that database is never called
+    mock_db.assert_not_called()
+
+
+def test_delete_previous_release():
+    # Prepare data for mock query responses
+    matches = {
+        "2022-04-01~1~A": {
+            "id": "2022-04-01~1",
+            "for": "A",
+            "participants": {"A": True, "B": True},
+            "release_tag": "2022-04-01",
+            "release_timestamp": TS_2022_04_01,
+            "title": None,
+        },
+        "2022-04-01~1~B": {
+            "id": "2022-04-01~1",
+            "for": "B",
+            "participants": {"A": True, "B": True},
+            "release_tag": "2022-04-01",
+            "release_timestamp": TS_2022_04_01,
+            "title": None,
+        },
+    }
+
+    # Mock database calls so that test does not actually query a database
+    mock_db = MagicMock()
+    # Note: MagicMock does not consider different arguments to chained calls as
+    # different calls, so we have to create a separate mock for each reference
+    mock_ref = {
+        "matches/test": MagicMock(),
+        "messages/test": MagicMock(),
+    }
+    mock_db.reference = MagicMock(side_effect=lambda path: mock_ref[path])
+
+    mock_get_matches = MagicMock(return_value=matches)
+    mock_ref["matches/test"].order_by_child("release_tag").equal_to(
+        "2022-04-01"
+    ).get = mock_get_matches
+
+    mock_delete_matches = MagicMock()
+    mock_ref["matches/test"].update = mock_delete_matches
+
+    mock_delete_chats = MagicMock()
+    mock_ref["messages/test"].update = mock_delete_chats
+
+    # Run Prefect task with mock
+    delete_previous_release.run(
+        mock_db,
+        community="test",
+        release_tag="2022-04-01",
+        now=DT_2022_03_31,
+        force=True,
+    )
+
+    # Verify that database was queried once with no parameters
+    mock_get_matches.assert_called_once_with()
+
+    # Verify that expected matches were deleted
+    expected_matches_to_delete = {
+        "2022-04-01~1~A": None,
+        "2022-04-01~1~B": None,
+    }
+    mock_delete_matches.assert_called_once_with(expected_matches_to_delete)
+
+    # Verify that expected chats were deleted
+    expected_chats_to_delete = {
+        "2022-04-01~1": None,
+    }
+    mock_delete_chats.assert_called_once_with(expected_chats_to_delete)
+
+
+def test_delete_previous_release_always_delete_future_release():
+    # Prepare data for mock query responses
+    matches = {
+        "2022-04-01~1~A": {
+            "id": "2022-04-01~1",
+            "for": "A",
+            "participants": {"A": True, "B": True},
+            "release_tag": "2022-04-01",
+            "release_timestamp": TS_2022_04_01,
+            "title": None,
+        },
+        "2022-04-01~1~B": {
+            "id": "2022-04-01~1",
+            "for": "B",
+            "participants": {"A": True, "B": True},
+            "release_tag": "2022-04-01",
+            "release_timestamp": TS_2022_04_01,
+            "title": None,
+        },
+    }
+
+    # Mock database calls so that test does not actually query a database
+    mock_db = MagicMock()
+    # Note: MagicMock does not consider different arguments to chained calls as
+    # different calls, so we have to create a separate mock for each reference
+    mock_ref = {
+        "matches/test": MagicMock(),
+        "messages/test": MagicMock(),
+    }
+    mock_db.reference = MagicMock(side_effect=lambda path: mock_ref[path])
+
+    mock_get_matches = MagicMock(return_value=matches)
+    mock_ref["matches/test"].order_by_child("release_tag").equal_to(
+        "2022-04-01"
+    ).get = mock_get_matches
+
+    mock_delete_matches = MagicMock()
+    mock_ref["matches/test"].update = mock_delete_matches
+
+    mock_delete_chats = MagicMock()
+    mock_ref["messages/test"].update = mock_delete_chats
+
+    # Run Prefect task with mock
+    # Note: Even though force is not set to True, this task will still run the
+    # delete operation because the release tag is in the future
+    delete_previous_release.run(
+        mock_db,
+        community="test",
+        release_tag="2022-04-01",
+        now=DT_2022_03_31,
+    )
+
+    # Verify that database was queried once with no parameters
+    mock_get_matches.assert_called_once_with()
+
+    # Verify that expected matches were deleted
+    expected_matches_to_delete = {
+        "2022-04-01~1~A": None,
+        "2022-04-01~1~B": None,
+    }
+    mock_delete_matches.assert_called_once_with(expected_matches_to_delete)
+
+    # Verify that expected chats were deleted
+    expected_chats_to_delete = {
+        "2022-04-01~1": None,
+    }
+    mock_delete_chats.assert_called_once_with(expected_chats_to_delete)
+
+
+def test_delete_previous_release_skip_delete_past_release_without_force():
+    # Mock database calls so that test does not actually query a database
+    mock_db = MagicMock()
+    mock_db.reference = MagicMock()
+
+    # Run Prefect task with mock
+    delete_previous_release.run(
+        mock_db,
+        community="test",
+        release_tag="2022-04-01",
+        now=DT_2022_04_02,
+    )
+
+    # Verify that database is never called
+    mock_db.reference.assert_not_called()

--- a/pipeline/matching_pipeline.py
+++ b/pipeline/matching_pipeline.py
@@ -14,6 +14,7 @@ from prefect import Flow, Parameter, task
 from prefect.tasks.secrets import PrefectSecret
 from pipeline.extract.users import extract_users
 from pipeline.extract.matches import extract_recent_matches
+from pipeline.load.release import delete_previous_release, upload_matches
 from pipeline.matching import (
     best_effort_minimize_repeat_matches,
     get_matches,
@@ -21,7 +22,6 @@ from pipeline.matching import (
 )
 from pipeline.schema.user import User
 from pipeline.schema.match import Match
-from pipeline.utils.constants import MS
 from pipeline.utils.firebase import initialize_firebase_for_prefect
 from pipeline.utils.release import (
     generate_keys,
@@ -88,104 +88,6 @@ def compute_matches(
     return df_matches
 
 
-@task
-def delete_previous_release(
-    db, community: str, release_tag: str, force: bool = False
-):
-    logger = prefect.context.get("logger")
-    release = from_release_tag(release_tag)
-    if force:
-        logger.info("Proceeding with forced deletion.")
-    elif release < datetime.datetime.now():
-        logger.warning(
-            (
-                "You are trying to delete a past round of matches.\n"
-                "Are you sure?\n"
-                "This will also delete any chats from those matches.\n"
-                "Skipped deleting records.\n"
-                "Use the `force` parameter to run this deletion."
-            )
-        )
-        return
-
-    # Get user-match records for the given community and release
-    matches_ref = db.reference(f"matches/{community}")
-    release_tag = to_release_tag(release)
-    query = matches_ref.order_by_child("release_tag").equal_to(release_tag)
-    match_records = query.get()
-    logger.info(f"Found {len(match_records)} user-match records to remove.")
-
-    # Add chat messages from those matches to the removal set
-    deleted_chats = {}
-    for match in match_records.values():
-        deleted_chats[match["id"]] = None
-
-    # Only remove if records are found, otherwise, we might accidentally
-    # delete all match user-records!
-    if match_records:
-        deleted_matches = {key: None for key in match_records}
-        matches_ref.update(deleted_matches)
-        logger.info(f"Removed {len(deleted_matches)} user-match records.")
-    else:
-        logger.info("No user-match records to remove.")
-
-    if deleted_chats:
-        chats_ref = db.reference(f"messages/{community}")
-        chats_ref.update(deleted_chats)
-        logger.info(f"Removed messages for {len(deleted_chats)} chats.")
-    else:
-        logger.info("No chat message records to remove.")
-
-
-@task
-def upload_matches(
-    db,
-    df_matches: pd.DataFrame,
-    community: str,
-    release_tag: str,
-    force: bool = False,
-):
-    logger = prefect.context.get("logger")
-    # Read matches into dataclass values
-    logger.info("Read {} rows, {} cols.".format(*df_matches.shape))
-    df_matches["release"] = df_matches["release"].apply(from_release_tag)
-    match_dicts = df_matches.to_dict(orient="records")
-    matches = [Match(**m) for m in match_dicts]
-
-    # Build match records for each user
-    res = {}
-    for m in matches:
-        release_tag = to_release_tag(m.release)
-        release_ts = m.release.timestamp() * MS
-        participants = {other_uid: True for other_uid in m.users}
-        match_id = f"{release_tag}~{m.key}"
-        for my_uid in m.users:
-            combo_id = f"{match_id}~{my_uid}"
-            path = f"{m.community}/{combo_id}"
-            record = {
-                "for": my_uid,
-                "participants": participants,
-                "release_tag": release_tag,
-                "release_timestamp": release_ts,
-                "title": m.title,
-                "id": match_id,
-            }
-            res[path] = record
-    logger.info(f"Generated {len(res)} user-match records.")
-
-    # Write matches to Firebase, if intended
-    if not force:
-        logger.warning(
-            (
-                "Dry run: Skipped writing records to Firebase.\n"
-                "Use the `force` parameter to apply this action."
-            )
-        )
-        return
-    matches_ref = db.reference("matches")
-    matches_ref.update(res)
-
-
 def matching_pipeline() -> Flow:
     with Flow(name="matching_pipeline") as flow:
         param_community = Parameter(name="community", required=True)
@@ -229,6 +131,6 @@ if __name__ == "__main__":
     flow.run(
         parameters={
             "community": "demo",
-            "release": "2022-04-10",
+            "release": "2022-04-17",
         }
     )

--- a/pipeline/matching_pipeline.py
+++ b/pipeline/matching_pipeline.py
@@ -11,6 +11,7 @@ import firebase_admin
 from firebase_admin import credentials, db
 import prefect
 from prefect import Flow, Parameter, task
+from prefect.tasks.core.constants import Constant
 from prefect.tasks.secrets import PrefectSecret
 from pipeline.extract.users import extract_users
 from pipeline.extract.matches import extract_recent_matches
@@ -94,6 +95,7 @@ def matching_pipeline() -> Flow:
         param_matching_retries = Parameter(name="matching_retries", default=5)
         param_release = Parameter(name="release", required=True)
         param_force = Parameter(name="force", required=False)
+        const_now = Constant(name="now", value=datetime.datetime.now())
 
         secret_database_url = PrefectSecret("database_url")
         secret_admin_credentials = PrefectSecret("admin_credentials")
@@ -113,7 +115,7 @@ def matching_pipeline() -> Flow:
 
         # Do not attempt deletion until new matches are ready
         deleted = delete_previous_release(
-            db, param_community, param_release, param_force
+            db, param_community, param_release, const_now, param_force
         )
         deleted.set_upstream(df_matches)
 

--- a/run.sh
+++ b/run.sh
@@ -5,6 +5,7 @@ set -e
 
 FRONTEND_PORT=4000
 BACKEND_PORT=8000
+PREFECT_DASHBOARD_PORT=8080
 
 if [ "$1" == "frontend" ]; then
   echo "Starting frontend app..."
@@ -124,6 +125,13 @@ elif [ "$1" == "prefect-register" ]; then
   source .venv/bin/activate
   prefect create project butterfly
   python3 pipeline/register_all_flows.py
+
+elif [ "$1" == "open-prefect" ]; then
+  if command -v gp &> /dev/null; then
+    gp preview $(gp url "$PREFECT_DASHBOARD_PORT")
+  else
+    open "http://localhost:$PREFECT_DASHBOARD_PORT"
+  fi
 
 else
   echo "No run shortcut found for: $1"


### PR DESCRIPTION
Contributes to #23.

Tested with mocked unit tests, as well as by running pipeline in Prefect and locally.

Writing the mocks for this was tough because of multiple calls to the `db.reference()` function. Keep in mind for #47.