### PR TITLE
Add and apply more Python pre-commit hooks.

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,7 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - name: Setup Python 3.8 🐍
+        uses: "actions/setup-python@v2"
+        with:
+          python-version: "3.8"
       - name: Install frontend dependencies
         run: ./run.sh install-frontend
       - uses: pre-commit/action@v2.0.3

--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -25,10 +25,10 @@ jobs:
       - name: Checkout 🛎️
         uses: actions/checkout@v2.3.1
 
-      - name: Setup Python 3.7 🐍
+      - name: Setup Python 3.8 🐍
         uses: "actions/setup-python@v2"
         with:
-          python-version: "3.7"
+          python-version: "3.8"
 
       - name: Install Backend Dependencies
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,10 @@ repos:
       - id: end-of-file-fixer
       - id: check-yaml
       - id: check-added-large-files
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.812
+    hooks:
+      - id: mypy
   - repo: https://github.com/ambv/black
     rev: 22.3.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,14 @@ repos:
       - id: end-of-file-fixer
       - id: check-yaml
       - id: check-added-large-files
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.7.4
+    hooks:
+      - id: bandit
+        # B101 detects usages of assert, even in tests, note that assert may not
+        # be available in production environments, so if your code relies on
+        # assert to avoid an insecure routine, it may not be protected.
+        args: [--skip, "B101"]
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.812
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,17 @@ repos:
         language: python
         types: [python]
         args: ["--line-length=80"]
+  - repo: https://github.com/hadialqattan/pycln
+    rev: v0.0.1-beta.3
+    hooks:
+      - id: pycln
+        args: ["all = true"]
+  - repo: https://github.com/pycqa/isort
+    rev: 5.5.4
+    hooks:
+      - id: isort
+        files: "\\.(py)$"
+        args: ["--profile", "black", "--line-length", "80"]
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.6.2
     hooks:

--- a/pipeline/extract/matches_test.py
+++ b/pipeline/extract/matches_test.py
@@ -1,5 +1,7 @@
-import pandas as pd
 from unittest.mock import MagicMock
+
+import pandas as pd
+
 from pipeline.extract.matches import extract_recent_matches
 
 

--- a/pipeline/extract/users_test.py
+++ b/pipeline/extract/users_test.py
@@ -1,4 +1,5 @@
 from unittest.mock import MagicMock
+
 from pipeline.extract.users import extract_users
 
 

--- a/pipeline/load/release_test.py
+++ b/pipeline/load/release_test.py
@@ -1,8 +1,9 @@
 import datetime
-import pandas as pd
 from unittest.mock import MagicMock
-from pipeline.load.release import delete_previous_release, upload_matches
 
+import pandas as pd
+
+from pipeline.load.release import delete_previous_release, upload_matches
 
 MS = 1000
 TS_2022_04_01 = datetime.datetime(2022, 4, 1).timestamp() * MS

--- a/pipeline/matching/algorithms/fallback/example.py
+++ b/pipeline/matching/algorithms/fallback/example.py
@@ -7,6 +7,7 @@ import sys
 sys.path.append("./")
 
 import datetime
+from typing import List
 
 from pipeline.matching.algorithms.fallback import get_fallback_matches
 from pipeline.matching.evaluation.validation import validate_matches
@@ -37,7 +38,7 @@ if __name__ == "__main__":
 
     # Validate past matches
     print("Validate Previous Matches:")
-    past_matches = []
+    past_matches: List[Match] = []
     for current_matches in week_matches:
         total, t2, t3 = validate_matches(current_matches, users, past_matches)
         print(f"\tTotal = {total}, T2: {t2}, T3: {t3}")

--- a/pipeline/matching/algorithms/fallback/optimizers.py
+++ b/pipeline/matching/algorithms/fallback/optimizers.py
@@ -23,7 +23,7 @@ def best_effort_minimize_repeat_matches(
 
             # Track the best output so far
             fewest_repeat_matches = len(users)
-            best_output = None
+            best_output: List[Match] = []
 
             for i in range(1, n_retries + 1):
                 # Run matching function

--- a/pipeline/matching/core/utils.py
+++ b/pipeline/matching/core/utils.py
@@ -1,7 +1,7 @@
 import random
 import string
 from collections import defaultdict
-from typing import DefaultDict, List
+from typing import DefaultDict, List, Set
 
 from pipeline.matching.core.types import RecentlyMatchedUsers
 from pipeline.schema.match import Match
@@ -35,7 +35,7 @@ def generate_keys(n: int, k: int = 8) -> List[str]:
       List of keys, unique within this batch.
     """
     # Start by maintaining a set to avoid duplicates
-    output = set()
+    output: Set[str] = set()
     # Key can be composed of uppercase or lowercase letters or numbers
     chars = string.ascii_letters + string.digits
     for _ in range(n):

--- a/pipeline/register_all_flows.py
+++ b/pipeline/register_all_flows.py
@@ -4,7 +4,6 @@ sys.path.append("./")
 
 from matching_pipeline import matching_pipeline
 
-
 PROJECT = "butterfly"
 FLOWS = [matching_pipeline]
 

--- a/pipeline/schema/match.py
+++ b/pipeline/schema/match.py
@@ -1,7 +1,8 @@
 import datetime
 from dataclasses import dataclass
-from pipeline.schema.user import UserId
 from typing import Optional, Set
+
+from pipeline.schema.user import UserId
 
 
 @dataclass

--- a/pipeline/schema/user.py
+++ b/pipeline/schema/user.py
@@ -1,6 +1,5 @@
 from dataclasses import dataclass
 
-
 UserId = str
 
 

--- a/pipeline/utils/firebase.py
+++ b/pipeline/utils/firebase.py
@@ -1,5 +1,6 @@
 import json
 import os
+
 import firebase_admin
 from decouple import Config, RepositoryEnv
 from firebase_admin import credentials, db

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+bandit==1.7.4
 black==22.3.0
 isort==5.10.1
 mypy==0.960

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 black==22.3.0
 isort==5.10.1
+mypy==0.960
 pre-commit==2.18.1
 pycln==1.3.3
 pytest==6.2.4


### PR DESCRIPTION
Closes #44.

- Added `isort` to sort imports.
  - Set profile to match `black` code formatter so that they do not undo each other's work.
- Added `pycln` to remove unused imports.
- Added `mypy` for static type analysis.
- Added `bandit` for security vulnerability analysis.
- Upgrade GitHub actions to use Python 3.8 to match Gitpod.