### PR TITLE
Reorganize Prefect flows in pipeline.flow module.

### DIFF
--- a/pipeline/flows/matching.py
+++ b/pipeline/flows/matching.py
@@ -16,8 +16,8 @@ from pipeline.matching.algorithms.fallback import compute_fallback_matches
 from pipeline.utils.firebase import initialize_firebase_for_prefect
 
 
-def matching_pipeline() -> Flow:
-    with Flow(name="matching_pipeline") as flow:
+def matching_flow() -> Flow:
+    with Flow(name="matching_flow") as flow:
         param_community = Parameter(name="community", required=True)
         param_matching_retries = Parameter(name="matching_retries", default=5)
         param_release = Parameter(name="release", required=True)
@@ -56,7 +56,7 @@ def matching_pipeline() -> Flow:
 
 
 if __name__ == "__main__":
-    flow = matching_pipeline()
+    flow = matching_flow()
     flow.run(
         parameters={
             "community": "demo",

--- a/pipeline/scripts/register_all_flows.py
+++ b/pipeline/scripts/register_all_flows.py
@@ -2,10 +2,10 @@ import sys
 
 sys.path.append("./")
 
-from matching_pipeline import matching_pipeline
+from pipeline.flows.matching import matching_flow
 
 PROJECT = "butterfly"
-FLOWS = [matching_pipeline]
+FLOWS = [matching_flow]
 
 
 if __name__ == "__main__":

--- a/run.sh
+++ b/run.sh
@@ -82,13 +82,15 @@ elif [ "$1" == "pytest" ]; then
   source .venv/bin/activate
   pytest "${@:2}"
 
-elif [ "$1" == "prefect-local-flow" ]; then
+elif [ "$1" == "flow" ]; then
   # Set Prefect secrets then run a flow
   source .venv/bin/activate
+  FLOW_NAME="$2"
+  PATH_TO_FLOW="pipeline/flows/$FLOW_NAME.py"
   if command -v gp &> /dev/null; then
-    env $(gp env) python3 "$2"
+    env $(gp env) python3 "$PATH_TO_FLOW"
   else
-    env $(cat .env.prefect | xargs) python3 "$2"
+    env $(cat .env.prefect | xargs) python3 "$PATH_TO_FLOW"
   fi
 
 elif [ "$1" == "prefect-dashboard" ]; then
@@ -101,7 +103,7 @@ elif [ "$1" == "prefect-dashboard" ]; then
   # Create project for flows
   prefect create project butterfly
   # Register latest version of flows
-  python3 pipeline/register_all_flows.py
+  python3 pipeline/scripts/register_all_flows.py
   # Show developer how to connect to local services
   if command -v gp &> /dev/null; then
     echo "Copy this URL into the Prefect Server GraphQL endpoint:"
@@ -124,7 +126,7 @@ elif [ "$1" == "prefect-register" ]; then
   # Register latest version of flows with Prefect Server
   source .venv/bin/activate
   prefect create project butterfly
-  python3 pipeline/register_all_flows.py
+  python3 pipeline/scripts/register_all_flows.py
 
 elif [ "$1" == "open-prefect" ]; then
   if command -v gp &> /dev/null; then


### PR DESCRIPTION
Closes #23.

## Usage

Now the commands for running offline pipelines are:

### From Command Line

```bash
# Run a flow locally by its name in the `pipeline/flows` directory
run flow matching
```

### From Dashboard

```bash
# Start Prefect dashboard running out of a container
run prefect-dashboard
# Open the dashboard on port 8080 and copy the graphql URL into the input
# Start prefect agent to receive flow runs
run prefect-agent
# Run flows from the dashboard
# Re-register the latest version of your local flows when you make changes
run prefect-register
# Shut off the container when you are done
prefect server stop
```