### PR TITLE
Remove scorer and rename fallback to finalizer.

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Setup Python 3.8.13 🐍
+      - name: Setup Python 3.8 🐍
         uses: "actions/setup-python@v3"
         with:
-          python-version: "3.8.13"
+          python-version: "3.8"
       - name: Install frontend dependencies
         run: ./run.sh install-frontend
       - uses: pre-commit/action@v2.0.3

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python 3.8.13 🐍
-        uses: "actions/setup-python@v2"
+        uses: "actions/setup-python@v3"
         with:
           python-version: "3.8.13"
       - name: Install frontend dependencies

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Setup Python 3.8 🐍
+      - name: Setup Python 3.8.13 🐍
         uses: "actions/setup-python@v2"
         with:
-          python-version: "3.8"
+          python-version: "3.8.13"
       - name: Install frontend dependencies
         run: ./run.sh install-frontend
       - uses: pre-commit/action@v2.0.3

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -15,5 +15,5 @@ jobs:
         with:
           python-version: "3.8"
       - name: Install frontend dependencies
-        run: ./run.sh install-frontend
+        run: ./run.sh install-frontend-ci
       - uses: pre-commit/action@v2.0.3

--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -25,10 +25,10 @@ jobs:
       - name: Checkout 🛎️
         uses: actions/checkout@v2.3.1
 
-      - name: Setup Python 3.8 🐍
+      - name: Setup Python 3.8.13 🐍
         uses: "actions/setup-python@v2"
         with:
-          python-version: "3.8"
+          python-version: "3.8.13"
 
       - name: Install Backend Dependencies
         run: |

--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -25,10 +25,10 @@ jobs:
       - name: Checkout 🛎️
         uses: actions/checkout@v2.3.1
 
-      - name: Setup Python 3.8.13 🐍
+      - name: Setup Python 3.8 🐍
         uses: "actions/setup-python@v3"
         with:
-          python-version: "3.8.13"
+          python-version: "3.8"
 
       - name: Install Backend Dependencies
         run: |

--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v2.3.1
 
       - name: Setup Python 3.8.13 🐍
-        uses: "actions/setup-python@v2"
+        uses: "actions/setup-python@v3"
         with:
           python-version: "3.8.13"
 

--- a/pipeline/matching/algorithms/fallback/optimizers.py
+++ b/pipeline/matching/algorithms/fallback/optimizers.py
@@ -26,7 +26,7 @@ def best_effort_minimize_repeat_matches(
             for i in range(1, n_retries + 1):
                 # Run matching function
                 log(f"Running attempt {i}...")
-                matches = do_matching(users, recent_matches)
+                matches = list(do_matching(users, recent_matches))
 
                 # Count repeat matches
                 n_repeat_matches = 0

--- a/pipeline/matching/core/engine.py
+++ b/pipeline/matching/core/engine.py
@@ -2,42 +2,37 @@ from typing import List, Set
 
 from pipeline.types import (
     Match,
-    MatchFallback,
+    MatchFinalizer,
     MatchGenerator,
     MatchingInput,
     MatchingOutput,
     MatchRanker,
-    MatchScorer,
-    ScoredMatch,
     UserId,
 )
 
 
 class MatchingEngine:
-    def __init__(self, generators, scorer, ranker, fallback):
+    def __init__(self, generators, ranker, finalizer):
         self.generators: List[MatchGenerator] = generators
-        self.scorer: MatchScorer = scorer
         self.ranker: MatchRanker = ranker
-        self.fallback: MatchFallback = fallback
+        self.finalizer: MatchFinalizer = finalizer
 
     def run(self, inp: MatchingInput) -> MatchingOutput:
         # Generate matches
-        proposed_matches: List[ScoredMatch] = []
+        proposed_matches: List[Match] = []
         for generate_matches in self.generators:
             for match in generate_matches(inp):
-                # Score matches
-                score = self.scorer(inp, match)
-                proposed_matches.append((match, score))
+                proposed_matches.append(match)
         # Rank matches
         selected_matches: List[Match] = []
         users_to_match: Set[UserId] = {u.uid for u in inp.users}
-        for match, score in self.ranker(inp, proposed_matches):
+        for match in self.ranker(inp, proposed_matches):
             if match.users.issubset(users_to_match):
                 selected_matches.append(match)
                 users_to_match.difference_update(match.users)
-        # Get users without a match
+        # Finalize matches for users without a match
         remaining_users = [u for u in inp.users if u.uid in users_to_match]
-        for match in self.fallback(remaining_users, inp.recent_matches):
+        for match in self.finalizer(remaining_users, inp.recent_matches):
             selected_matches.append(match)
         # Return output
         return MatchingOutput(

--- a/pipeline/matching/core/engine_test.py
+++ b/pipeline/matching/core/engine_test.py
@@ -33,16 +33,14 @@ def test_engine_basic():
     )
 
     # Prepare matching engine
-    fixed_generator_1 = MagicMock(return_value=[make_match_between("A", "C")])
-    fixed_generator_2 = MagicMock(return_value=[make_match_between("A", "D")])
-    fixed_scorer = MagicMock(return_value=1.0)
-    fixed_ranker = MagicMock(side_effect=lambda x, y: [m for m in y])
-    fixed_fallback = MagicMock(return_value=[make_match_between("B", "D", "E")])
+    mock_generator_1 = MagicMock(return_value=[make_match_between("A", "C")])
+    mock_generator_2 = MagicMock(return_value=[make_match_between("A", "D")])
+    mock_ranker = MagicMock(side_effect=lambda x, y: [m for m in y])
+    mock_finalizer = MagicMock(return_value=[make_match_between("B", "D", "E")])
     engine = MatchingEngine(
-        generators=[fixed_generator_1, fixed_generator_2],
-        scorer=fixed_scorer,
-        ranker=fixed_ranker,
-        fallback=fixed_fallback,
+        generators=[mock_generator_1, mock_generator_2],
+        ranker=mock_ranker,
+        finalizer=mock_finalizer,
     )
 
     # Run matching engine and verify expected outputs

--- a/pipeline/types/engine.py
+++ b/pipeline/types/engine.py
@@ -1,4 +1,4 @@
-from typing import Callable, Iterator, List, Set, Tuple
+from typing import Callable, Iterator, List, Set
 
 from pipeline.types.match import Match, MatchingInput, MatchingOutput
 from pipeline.types.user import User, UserId
@@ -6,14 +6,8 @@ from pipeline.types.user import User, UserId
 RecentMatch = Match
 RecentlyMatchedUsers = Set[UserId]
 
-MatchingFunction = Callable[[List[User], List[RecentMatch]], List[Match]]
-
-Score = float
-ScoredMatch = Tuple[Match, Score]
+MatchingFunction = Callable[[List[User], List[RecentMatch]], Iterator[Match]]
 
 MatchGenerator = Callable[[MatchingInput], Iterator[Match]]
-MatchScorer = Callable[[MatchingInput, Match], Score]
-MatchRanker = Callable[
-    [MatchingInput, List[ScoredMatch]], Iterator[ScoredMatch]
-]
-MatchFallback = Callable[[List[User], List[RecentMatch]], Iterator[Match]]
+MatchRanker = Callable[[MatchingInput, List[Match]], Iterator[Match]]
+MatchFinalizer = MatchingFunction

--- a/run.sh
+++ b/run.sh
@@ -50,6 +50,12 @@ elif [ "$1" == "install-frontend" ]; then
   cd frontend
   npm install
 
+elif [ "$1" == "install-frontend-ci" ]; then
+  echo "Installing frontend dependencies for continuous integration runner..."
+  # Install using package-lock.json instead of rebuilding dependency tree
+  cd frontend
+  npm ci
+
 elif [ "$1" == "lint-frontend" ]; then
   cd frontend
   npm run lint "${@:2}"


### PR DESCRIPTION
Don't need the scorer because generators will be able to write their own scores into match metadata and rankers can choose any method of ranking proposed matches, not just based on scores.

Also ran into slight differences with mypy between Python 3.8.13 (Gitpod default) and Python 3.8.12 (GitHub 3.8 default), trying to fix those as well as reduce the runtime of the pre-commit CI job.

Using [`npm ci`](https://stackoverflow.com/a/52733682) sped up the pre-commit job from 1m44s to 1m0s.