### PR TITLE
Add metadata to Match schema.

### DIFF
--- a/pipeline/extract/matches.py
+++ b/pipeline/extract/matches.py
@@ -27,6 +27,7 @@ def extract_recent_matches(db, community: str) -> pd.DataFrame:
             release=from_release_tag(record["release_tag"]),
             key=match_key,
             title=record["title"],
+            metadata=record.get("metadata", {}),
         )
         recent_match_records.append(match)
     logger.info(f"Converted to {len(recent_match_records)} match records.")

--- a/pipeline/extract/matches_test.py
+++ b/pipeline/extract/matches_test.py
@@ -7,31 +7,33 @@ from pipeline.extract.matches import extract_recent_matches
 
 def test_extract_recent_matches_converts_user_match_records_to_match_records():
     # Mock database call so that test does not actually query a database
-    default_expected = {"title": None}
+    default_record = {"title": None}
     matches = {
         "1~A": {
-            **default_expected,
+            **default_record,
             "id": "1",
             "participants": ["A", "B"],
             "release_tag": "2022-04-01",
         },
         "1~B": {
-            **default_expected,
+            **default_record,
             "id": "1",
             "participants": ["B", "A"],
             "release_tag": "2022-04-01",
         },
         "2~C": {
-            **default_expected,
+            **default_record,
             "id": "2",
             "participants": ["C", "D"],
             "release_tag": "2022-04-07",
+            "metadata": {"score": 1.25},
         },
         "2~D": {
-            **default_expected,
+            **default_record,
             "id": "2",
             "participants": ["D", "C"],
             "release_tag": "2022-04-07",
+            "metadata": {"score": 1.25},
         },
     }
     mock_get_matches = MagicMock(return_value=matches)
@@ -46,7 +48,7 @@ def test_extract_recent_matches_converts_user_match_records_to_match_records():
     mock_get_matches.assert_called_once_with()
 
     # Verify that only one record per match is returned
-    default_expected = {"title": None, "community": "test"}
+    default_expected = {"title": None, "community": "test", "metadata": {}}
     expected = [
         {
             **default_expected,
@@ -59,6 +61,7 @@ def test_extract_recent_matches_converts_user_match_records_to_match_records():
             "key": "2",
             "users": {"C", "D"},
             "release": pd.Timestamp(2022, 4, 7),
+            "metadata": {"score": 1.25},
         },
     ]
     assert actual == expected

--- a/pipeline/load/release.py
+++ b/pipeline/load/release.py
@@ -103,6 +103,7 @@ def upload_matches(
                 "release_timestamp": release_ts,
                 "title": m.title,
                 "id": match_id,
+                "metadata": m.metadata,
             }
             res[path] = record
     logger.info(f"Generated {len(res)} user-match records.")

--- a/pipeline/load/release_test.py
+++ b/pipeline/load/release_test.py
@@ -17,7 +17,7 @@ def test_upload_matches_per_user_for_current_release():
     mock_db = MagicMock()
     mock_db.reference("matches").update = mock_update_matches
 
-    default_match = {"title": None, "community": "test"}
+    default_match = {"title": None, "community": "test", "metadata": {}}
     matches = [
         {
             **default_match,
@@ -30,6 +30,13 @@ def test_upload_matches_per_user_for_current_release():
             "key": "2",
             "release": "2022-04-07",
             "users": {"C", "D"},
+        },
+        {
+            **default_match,
+            "key": "3",
+            "release": "2022-04-01",
+            "users": {"C", "D"},
+            "metadata": {"score": 1.25},
         },
     ]
 
@@ -52,6 +59,7 @@ def test_upload_matches_per_user_for_current_release():
             "release_tag": "2022-04-01",
             "release_timestamp": TS_2022_04_01,
             "title": None,
+            "metadata": {},
         },
         "test/2022-04-01~1~B": {
             "id": "2022-04-01~1",
@@ -60,6 +68,25 @@ def test_upload_matches_per_user_for_current_release():
             "release_tag": "2022-04-01",
             "release_timestamp": TS_2022_04_01,
             "title": None,
+            "metadata": {},
+        },
+        "test/2022-04-01~3~C": {
+            "id": "2022-04-01~3",
+            "for": "C",
+            "participants": {"C": True, "D": True},
+            "release_tag": "2022-04-01",
+            "release_timestamp": TS_2022_04_01,
+            "title": None,
+            "metadata": {"score": 1.25},
+        },
+        "test/2022-04-01~3~D": {
+            "id": "2022-04-01~3",
+            "for": "D",
+            "participants": {"C": True, "D": True},
+            "release_tag": "2022-04-01",
+            "release_timestamp": TS_2022_04_01,
+            "title": None,
+            "metadata": {"score": 1.25},
         },
     }
     # Verify that the expected data was sent to the database

--- a/pipeline/matching/core/engine_test.py
+++ b/pipeline/matching/core/engine_test.py
@@ -4,26 +4,18 @@ from pipeline.matching.core.engine import MatchingEngine
 from pipeline.types import Match, MatchingInput, MatchingOutput, User, UserId
 
 
-def make_test_user(uid: UserId) -> User:
-    return User(uid=uid, displayName=f"User {uid}")
-
-
-def make_match_between(*uids) -> Match:
-    return Match(users=set(uids))
-
-
 def test_engine_basic():
     # Prepare inputs
     users = [
-        make_test_user("A"),
-        make_test_user("B"),
-        make_test_user("C"),
-        make_test_user("D"),
-        make_test_user("E"),
+        User(uid="A", displayName="User A"),
+        User(uid="B", displayName="User B"),
+        User(uid="C", displayName="User C"),
+        User(uid="D", displayName="User D"),
+        User(uid="E", displayName="User E"),
     ]
     recent_matches = [
-        make_match_between("A", "B"),
-        make_match_between("C", "D", "E"),
+        Match(users={"A", "B"}),
+        Match(users={"C", "D", "E"}),
     ]
     inp = MatchingInput(
         community="test",
@@ -33,10 +25,10 @@ def test_engine_basic():
     )
 
     # Prepare matching engine
-    mock_generator_1 = MagicMock(return_value=[make_match_between("A", "C")])
-    mock_generator_2 = MagicMock(return_value=[make_match_between("A", "D")])
+    mock_generator_1 = MagicMock(return_value=[Match(users={"A", "C"})])
+    mock_generator_2 = MagicMock(return_value=[Match(users={"A", "D"})])
     mock_ranker = MagicMock(side_effect=lambda x, y: [m for m in y])
-    mock_finalizer = MagicMock(return_value=[make_match_between("B", "D", "E")])
+    mock_finalizer = MagicMock(return_value=[Match(users={"B", "D", "E"})])
     engine = MatchingEngine(
         generators=[mock_generator_1, mock_generator_2],
         ranker=mock_ranker,
@@ -46,8 +38,8 @@ def test_engine_basic():
     # Run matching engine and verify expected outputs
     actual = engine.run(inp)
     expected_matches = [
-        make_match_between("A", "C"),
-        make_match_between("B", "D", "E"),
+        Match(users={"A", "C"}),
+        Match(users={"B", "D", "E"}),
     ]
     expected = MatchingOutput(
         community="test",

--- a/pipeline/types/match.py
+++ b/pipeline/types/match.py
@@ -1,14 +1,17 @@
 import datetime
-from dataclasses import dataclass
-from typing import List, Optional, Set
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Set
 
 from pipeline.types.release import Community, ReleaseTag
 from pipeline.types.user import User, UserId
+
+MatchMetadata = Dict
 
 
 @dataclass
 class Match:
     users: Set[UserId]
+    metadata: Dict = field(default_factory=dict)
     community: Optional[str] = None
     release: Optional[datetime.datetime] = None
     key: Optional[str] = None


### PR DESCRIPTION
The `metadata` field of a `Match` is a dictionary that can be populated with any fields needed by the matching engine or other transformations. Because it is unstructured, callers must be careful to check that the field they think exists actually does and have fallbacks in case it does not.

In the future, we can create a dataclass for Match metadata that specifies all the possible fields and types. All of these fields would have to be optional with defaults, otherwise the Match API becomes cluttered with specific details from non-core code. We would also then need to make sure the Match metadata can be easily converted to a format that can be serialized/deserialized from the database. For that purpose, a dictionary works well.

Note that dataclass field defaults cannot be mutable, so instead of setting the default to a literal dictionary, we use the `field` method and define a factory function that returns a new dictionary each time a Match is initialized.

Minimal refactoring of other code was necessary to add this, updated tests and run the matching flow to ensure that the pipeline can handle both missing and populated metadata correctly.