### PR TITLE
Rank matches based on number of unique common letters in user names.

### DIFF
--- a/pipeline/matching/generators/satirical.py
+++ b/pipeline/matching/generators/satirical.py
@@ -3,6 +3,9 @@ from typing import Iterator, Set
 
 from pipeline.types import Match, MatchGenerator, MatchingInput
 
+GENERATOR_COMMON_LETTERS = "commonLetterGenerator"
+METADATA_FIELD_COMMON_LETTERS = "commonLetters"
+
 
 def get_unique_letters_from_name(name: str) -> Set[str]:
     return set(name.lower())
@@ -22,8 +25,16 @@ def configure_common_letter_generator(min_common: int = 0) -> MatchGenerator:
         for user_a, user_b in combinations(inp.users, r=2):
             letters_a = get_unique_letters_from_name(user_a.displayName)
             letters_b = get_unique_letters_from_name(user_b.displayName)
-            n_common = len(letters_a.intersection(letters_b))
-            if n_common >= min_common:
-                yield Match(users={user_a.uid, user_b.uid})
+            common_letters = letters_a.intersection(letters_b)
+            n_common = len(common_letters)
+            if n_common < min_common:
+                continue
+            metadata = {
+                "generator": GENERATOR_COMMON_LETTERS,
+                GENERATOR_COMMON_LETTERS: {
+                    METADATA_FIELD_COMMON_LETTERS: common_letters
+                },
+            }
+            yield Match(users={user_a.uid, user_b.uid}, metadata=metadata)
 
     return generator

--- a/pipeline/matching/generators/satirical_test.py
+++ b/pipeline/matching/generators/satirical_test.py
@@ -1,7 +1,17 @@
+from typing import Dict, Set
+
 from pipeline.matching.generators.satirical import (
     configure_common_letter_generator,
 )
 from pipeline.types import Match, MatchingInput, User
+
+
+def make_letter_metadata(common_letters: Set[str]) -> Dict:
+    """Helper to make expected metadata for common letter generator."""
+    return {
+        "generator": "commonLetterGenerator",
+        "commonLetterGenerator": {"commonLetters": common_letters},
+    }
 
 
 def test_common_letter_generator_no_minimum():
@@ -18,9 +28,9 @@ def test_common_letter_generator_no_minimum():
     generator = configure_common_letter_generator()
     actual = list(generator(inp))
     expected = [
-        Match(users={"1", "2"}),
-        Match(users={"1", "3"}),
-        Match(users={"2", "3"}),
+        Match(users={"1", "2"}, metadata=make_letter_metadata({"a", "n"})),
+        Match(users={"1", "3"}, metadata=make_letter_metadata({"a", "n"})),
+        Match(users={"2", "3"}, metadata=make_letter_metadata({"a", "n"})),
     ]
     assert actual == expected
 
@@ -38,5 +48,10 @@ def test_common_letter_generator_min_common():
     )
     generator = configure_common_letter_generator(min_common=3)
     actual = list(generator(inp))
-    expected = [Match(users={"1", "2"})]
+    expected = [
+        Match(
+            users={"1", "2"},
+            metadata=make_letter_metadata({"b", "e", "n"}),
+        )
+    ]
     assert actual == expected

--- a/pipeline/matching/rankers/satirical.py
+++ b/pipeline/matching/rankers/satirical.py
@@ -1,0 +1,22 @@
+from typing import Iterator, List
+
+from pipeline.matching.generators.satirical import (
+    GENERATOR_COMMON_LETTERS,
+    METADATA_FIELD_COMMON_LETTERS,
+)
+from pipeline.types import Match, MatchingInput
+
+
+def get_common_letters(match: Match):
+    if match.metadata.get("generator", "") != GENERATOR_COMMON_LETTERS:
+        return -1
+    metadata_fields = match.metadata.get(GENERATOR_COMMON_LETTERS, {})
+    common_letters = metadata_fields.get(METADATA_FIELD_COMMON_LETTERS, {})
+    return len(common_letters)
+
+
+def common_letter_ranker(
+    inp: MatchingInput, proposed: List[Match]
+) -> Iterator[Match]:
+    """Ranks matches by giving priority to matches from the common letter generator with the most number of unique letters in common, all other generated matches are given lower priority."""
+    yield from sorted(proposed, key=get_common_letters, reverse=True)

--- a/pipeline/matching/rankers/satirical.py
+++ b/pipeline/matching/rankers/satirical.py
@@ -18,5 +18,9 @@ def get_common_letters(match: Match):
 def common_letter_ranker(
     inp: MatchingInput, proposed: List[Match]
 ) -> Iterator[Match]:
-    """Ranks matches by giving priority to matches from the common letter generator with the most number of unique letters in common, all other generated matches are given lower priority."""
+    """
+    Ranks matches by giving priority to matches from the common letter
+    generator with the most number of unique letters in common, all other
+    generated matches are given lower priority.
+    """
     yield from sorted(proposed, key=get_common_letters, reverse=True)

--- a/pipeline/matching/rankers/satirical_test.py
+++ b/pipeline/matching/rankers/satirical_test.py
@@ -1,0 +1,21 @@
+from pipeline.matching.generators.satirical_test import make_letter_metadata
+from pipeline.matching.rankers.satirical import common_letter_ranker
+from pipeline.types import Match, MatchingInput
+
+
+def test_common_letter_ranker():
+    inp = MatchingInput(
+        community="test", release="2022-04-01", users=[], recent_matches=[]
+    )
+    proposed = [
+        Match(users={"A", "B"}),
+        Match(users={"C", "D"}, metadata=make_letter_metadata({"c", "a", "r"})),
+        Match(users={"E", "F"}, metadata=make_letter_metadata({"j", "i"})),
+    ]
+    actual = list(common_letter_ranker(inp, proposed))
+    expected = [
+        Match(users={"C", "D"}, metadata=make_letter_metadata({"c", "a", "r"})),
+        Match(users={"E", "F"}, metadata=make_letter_metadata({"j", "i"})),
+        Match(users={"A", "B"}),
+    ]
+    assert actual == expected


### PR DESCRIPTION
Follow-up to #61 intended to show how to add custom metadata to a generated match and then how to write a ranker that uses that metadata.

Match metadata should be namespaced to the specific component that uses it, to avoid conflicts with other components. In this case, we include the `generator` metadata field to tell downstream components which generator proposed this match. We also put all the metadata inside a nested field that has the name of the generator. This helps in case other components add their own metadata, which they should do in their own nested field to avoid interfering with this data.

Now we can use this metadata not only in the ranker, but even in the app. For example, now we can show users why they were matched as a conversation starter... which could show them the unique letters they have in common in their name 😂 