### PR TITLE
Add SatiricalMatchingEngine as an example.

### DIFF
--- a/pipeline/flows/matching.py
+++ b/pipeline/flows/matching.py
@@ -96,7 +96,7 @@ def matching_flow() -> Flow:
 
         # Do not attempt upload until previous release deletion resolved
         uploaded = upload_matches(
-            db, df_matches, param_community, param_release, param_force
+            db, df_output_matches, param_community, param_release, param_force
         )
         uploaded.set_upstream(deleted)
 

--- a/pipeline/matching/engines/config.py
+++ b/pipeline/matching/engines/config.py
@@ -1,3 +1,4 @@
 from pipeline.matching.engines.main import MainMatchingEngine
+from pipeline.matching.engines.satirical import SatiricalMatchingEngine
 
-ENGINES = {"main": MainMatchingEngine}
+ENGINES = {"main": MainMatchingEngine, "satirical": SatiricalMatchingEngine}

--- a/pipeline/matching/engines/satirical.py
+++ b/pipeline/matching/engines/satirical.py
@@ -1,0 +1,17 @@
+from pipeline.matching.core.engine import MatchingEngine
+from pipeline.matching.finalizers.fallbacks import (
+    finalize_fallbacks_with_retries,
+)
+from pipeline.matching.generators.satirical import (
+    configure_generate_common_letters,
+)
+from pipeline.matching.rankers.satirical import rank_common_letters
+
+
+class SatiricalMatchingEngine(MatchingEngine):
+    def __init__(self):
+        super().__init__(
+            generators=[configure_generate_common_letters(min_common=1)],
+            ranker=rank_common_letters,
+            finalizer=finalize_fallbacks_with_retries(n=5),
+        )

--- a/pipeline/matching/engines/satirical_test.py
+++ b/pipeline/matching/engines/satirical_test.py
@@ -1,0 +1,38 @@
+from pipeline.matching.engines.satirical import SatiricalMatchingEngine
+from pipeline.matching.generators.satirical_test import make_letter_metadata
+from pipeline.types import Match, MatchingInput, MatchingOutput, User, UserId
+
+
+def test_engine_basic():
+    # Prepare inputs
+    users = [
+        User(uid="1", displayName="Akshaya"),
+        User(uid="2", displayName="Yavin"),
+        User(uid="3", displayName="Colt"),
+        User(uid="4", displayName="Jurgen"),
+    ]
+    recent_matches = []
+    inp = MatchingInput(
+        community="test",
+        release="2022-04-01",
+        users=users,
+        recent_matches=recent_matches,
+    )
+
+    # Run matching engine
+    engine = SatiricalMatchingEngine()
+    actual = engine.run(inp)
+    print(actual.matches)
+
+    # Verify expected outputs
+    expected_matches = [
+        Match(users={"1", "2"}, metadata=make_letter_metadata(["a", "y"])),
+        Match(users={"3", "4"}),
+    ]
+    expected = MatchingOutput(
+        community="test",
+        release="2022-04-01",
+        users=users,
+        matches=expected_matches,
+    )
+    assert actual == expected

--- a/pipeline/matching/generators/satirical.py
+++ b/pipeline/matching/generators/satirical.py
@@ -8,7 +8,7 @@ METADATA_FIELD_COMMON_LETTERS = "commonLetters"
 
 
 def get_unique_letters_from_name(name: str) -> Set[str]:
-    return set(name.lower())
+    return set(name.lower().replace(" ", ""))
 
 
 def configure_generate_common_letters(min_common: int = 0) -> MatchGenerator:
@@ -32,7 +32,7 @@ def configure_generate_common_letters(min_common: int = 0) -> MatchGenerator:
             metadata = {
                 "generator": GENERATOR_COMMON_LETTERS,
                 GENERATOR_COMMON_LETTERS: {
-                    METADATA_FIELD_COMMON_LETTERS: common_letters
+                    METADATA_FIELD_COMMON_LETTERS: list(sorted(common_letters))
                 },
             }
             yield Match(users={user_a.uid, user_b.uid}, metadata=metadata)

--- a/pipeline/matching/generators/satirical_test.py
+++ b/pipeline/matching/generators/satirical_test.py
@@ -1,4 +1,4 @@
-from typing import Dict, Set
+from typing import Dict, List
 
 from pipeline.matching.generators.satirical import (
     configure_generate_common_letters,
@@ -6,7 +6,7 @@ from pipeline.matching.generators.satirical import (
 from pipeline.types import Match, MatchingInput, User
 
 
-def make_letter_metadata(common_letters: Set[str]) -> Dict:
+def make_letter_metadata(common_letters: List[str]) -> Dict:
     """Helper to make expected metadata for common letter generator."""
     return {
         "generator": "generateCommonLetters",
@@ -19,18 +19,18 @@ def test_generate_common_letters_no_minimum():
         community="test",
         release="2022-04-01",
         users=[
-            User(uid="1", displayName="Anna"),
-            User(uid="2", displayName="Ankur"),
-            User(uid="3", displayName="Anna"),
+            User(uid="1", displayName="Anna L"),
+            User(uid="2", displayName="Ankur P"),
+            User(uid="3", displayName="Anna L"),
         ],
         recent_matches=[],
     )
     generate = configure_generate_common_letters()
     actual = list(generate(inp))
     expected = [
-        Match(users={"1", "2"}, metadata=make_letter_metadata({"a", "n"})),
-        Match(users={"1", "3"}, metadata=make_letter_metadata({"a", "n"})),
-        Match(users={"2", "3"}, metadata=make_letter_metadata({"a", "n"})),
+        Match(users={"1", "2"}, metadata=make_letter_metadata(["a", "n"])),
+        Match(users={"1", "3"}, metadata=make_letter_metadata(["a", "l", "n"])),
+        Match(users={"2", "3"}, metadata=make_letter_metadata(["a", "n"])),
     ]
     assert actual == expected
 
@@ -51,7 +51,7 @@ def test_generate_common_letters_min_common():
     expected = [
         Match(
             users={"1", "2"},
-            metadata=make_letter_metadata({"b", "e", "n"}),
+            metadata=make_letter_metadata(["b", "e", "n"]),
         )
     ]
     assert actual == expected

--- a/pipeline/matching/rankers/satirical_test.py
+++ b/pipeline/matching/rankers/satirical_test.py
@@ -9,13 +9,13 @@ def test_rank_common_letters():
     )
     proposed = [
         Match(users={"A", "B"}),
-        Match(users={"C", "D"}, metadata=make_letter_metadata({"c", "a", "r"})),
-        Match(users={"E", "F"}, metadata=make_letter_metadata({"j", "i"})),
+        Match(users={"C", "D"}, metadata=make_letter_metadata(["c", "a", "r"])),
+        Match(users={"E", "F"}, metadata=make_letter_metadata(["j", "i"])),
     ]
     actual = list(rank_common_letters(inp, proposed))
     expected = [
-        Match(users={"C", "D"}, metadata=make_letter_metadata({"c", "a", "r"})),
-        Match(users={"E", "F"}, metadata=make_letter_metadata({"j", "i"})),
+        Match(users={"C", "D"}, metadata=make_letter_metadata(["c", "a", "r"])),
+        Match(users={"E", "F"}, metadata=make_letter_metadata(["j", "i"])),
         Match(users={"A", "B"}),
     ]
     assert actual == expected


### PR DESCRIPTION
## Summary

Incorporates the generator created in #61 and the ranker created in #63 into a matching engine and adds it as an engine you can run in the matching flow.

Also changes the behavior of the common letter generator to ignore spaces and to return a list instead of a set in the metadata, because a set cannot be written to Firebase.

Also fixes a bug in the matching flow where it tried to load the extracted matches (but did not because it checked the release label) instead of the output matches.

## Running in Prefect

Run parameters in Prefect are:

```json
{
  "community": "demo",
  "engine": "satirical",
  "force": true,
  "release": "2022-04-17"
} 
```

To run from the Prefect dashboard, I followed these steps:

```bash
run prefect-dashboard
# Copied the graphql URL, pasted it in the dashboard, selected the default tenant
run prefect-agent
run prefect-register # anytime I made changes
prefect server stop # when I finished
```