### PR TITLE
Change type interfaces to non-default exports.

### DIFF
--- a/frontend/src/app/types/ChatData.tsx
+++ b/frontend/src/app/types/ChatData.tsx
@@ -1,6 +1,6 @@
-import UserData from './UserData'
+import { UserData } from './UserData'
 
-export default interface ChatData {
+export interface ChatData {
     // ID for the match this chat is for, release tag plus match key
     id: string
     // Whether or not a chat with this match ID exists

--- a/frontend/src/app/types/UserData.tsx
+++ b/frontend/src/app/types/UserData.tsx
@@ -1,4 +1,4 @@
-export default interface UserData {
+export interface UserData {
     // ID for the user, unique across the app
     uid: string
     // Name of the user to display in the app


### PR DESCRIPTION
I am having trouble getting starred default exports to work in `index.js`, at least the code editor treats them as incorrect. Changing these last two to non-default exports for now to suppress the error.