### PR TITLE
Fix public asset import.

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
         <title>Butterfly</title>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <link rel="icon" type="image/png" href="/public/assets/logo-butterfly-rainbow.png" />
+        <link rel="icon" type="image/png" href="/assets/logo-butterfly-rainbow.png" />
     </head>
     <body>
         <div id="root"></div>

--- a/frontend/public/404.html
+++ b/frontend/public/404.html
@@ -4,7 +4,7 @@
         <title>Butterfly</title>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <link rel="icon" type="image/png" href="/public/assets/logo-butterfly-rainbow.png" />
+        <link rel="icon" type="image/png" href="/assets/logo-butterfly-rainbow.png" />
     </head>
     <body>
         <script type="text/javascript">

--- a/frontend/src/app/ui/Logo.jsx
+++ b/frontend/src/app/ui/Logo.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import './Logo.css'
-import logoUrl from '../../../public/assets/logo-butterfly-rainbow.png'
+// eslint-disable-next-line
+import logoUrl from '/assets/logo-butterfly-rainbow.png'
 
 export default function Logo({ size, align }) {
     return (


### PR DESCRIPTION
To make the warning in the Vite build log go away. Unfortunately, ESLint doesn't like what Vite recommends, so I decided to add an ignore for the line where the asset source is imported. We will have to do this in all such cases :(

Tested by building the static site and running it on GitPod: `run frontend-static`.