### PR TITLE
Only run pre-commit on changed files.

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -25,5 +25,14 @@ jobs:
       - name: Install Frontend Dependencies 🔧
         run: ./run.sh install-frontend-ci
 
+      - name: Get File Changes 📁
+        uses: trilom/file-changes-action@v1.2.4
+        id: file_changes
+        with:
+          prNumber: ${{ github.event.number }}
+          output: "space"
+
       - name: Run Pre-Commit 🖊️
         uses: pre-commit/action@v3.0.0
+        with:
+          extra_args: --files ${{ steps.file_changes.outputs.files }}


### PR DESCRIPTION
## Motivation

I referenced [this issue](https://github.com/pre-commit/action/issues/7) from the action repository.

I hope this will make the pre-commit action run faster. I think the frontend install is the main bottleneck though, and we already tried #49 to use `npm ci` instead of `npm i`.

It should be okay to run pre-commit only on changed files, since unchanged files either already pass, or were overridden by a previous force merge and should not count against the current PR.

## Results

This is good, let's use this change!

Here is a [comparable run](https://github.com/scarletstudio/butterfly/runs/6856092532?check_suite_focus=true) for a commit that makes a one line change to one action config file, the pre-commit step takes 26s.

In [this run for this pull request](https://github.com/scarletstudio/butterfly/runs/6912922680?check_suite_focus=true) which changes a few lines on one action config file, the pre-commit step takes just 6s.