### PR TITLE
Try to nest manifest scope.

### DIFF
--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -5,7 +5,7 @@
     "background_color": "#1b0e64",
     "display": "standalone",
     "orientation": "portrait",
-    "scope": "/",
+    "scope": "/butterfly",
     "start_url": "/",
     "icons": [
         {


### PR DESCRIPTION
The Android add to home screen feature works on the GitPod-hosted site, but not when it deploys to GitHub pages, instead of showing our app icon, it shows a red G. I wonder if the red comes from the parent site (Scarlet Data Studio website), but I have no idea what the G is, maybe GitHub.

Let's see if setting the scope to /butterfly tells the add to home screen to use the nested site config. Hooray for testing in prod.