### PR TITLE
Wake up server on page load.

### DIFF
--- a/backend/server/views_test.py
+++ b/backend/server/views_test.py
@@ -1,0 +1,12 @@
+from django.test import Client
+
+from backend.testing import assert_response_match, with_mock_db
+from backend.utils import format_json
+
+
+def test_hello():
+    c = Client()
+    actual = c.post("/")
+
+    expected = format_json(message="Hello! The backend is up and running.")
+    assert_response_match(actual, expected)

--- a/frontend/src/app/data/ConnectToServer.jsx
+++ b/frontend/src/app/data/ConnectToServer.jsx
@@ -1,0 +1,91 @@
+/* global localStorage */
+
+import React, { useEffect, useState } from 'react'
+import { Notification } from '../ui'
+
+const BACKEND_URL = import.meta.env.VITE_BACKEND_URL
+const LOCAL_STORAGE_LAST_PING = 'butterfly__last_ping'
+const WAIT_MS_BEFORE_NEXT_PING = 1000 * 60 * 5 // 5 mins in ms
+
+const SERVER_MESSAGES = {
+    LOADING: 'Connecting to our server...',
+    SUCCESS: 'Connected successfully!',
+    FAILURE: 'Could not connect. Please reload page.',
+}
+
+/*
+ * Send a request to wake up our server.
+ * Return a promise that always resolves, even if there is a failure.
+ * Will resolve with true if success, false if failure.
+ */
+async function pingServer() {
+    return new Promise((resolve) => {
+        fetch(`${BACKEND_URL}/`)
+            .then(() => resolve(true))
+            .catch(() => resolve(false))
+    })
+}
+
+function getConnectionOutcome(isLoading, isSuccess) {
+    if (isLoading) return ''
+    return isSuccess ? 'Success' : 'Failure'
+}
+
+function getConnectionMessage(isLoading, isSuccess) {
+    if (isLoading) return SERVER_MESSAGES.LOADING
+    return isSuccess ? SERVER_MESSAGES.SUCCESS : SERVER_MESSAGES.FAILURE
+}
+
+export default function ConnectToServer({ pingFn = pingServer }) {
+    const [isLoading, setIsLoading] = useState(true)
+    const [isSuccess, setIsSuccess] = useState(true)
+    const [isVisible, setIsVisible] = useState(true)
+
+    useEffect(() => {
+        let isSubscribed = true
+        let openTimer = null
+        let closeTimer = null
+
+        // Only send ping if ping has not been sent recently.
+        const lastPing = localStorage.getItem(LOCAL_STORAGE_LAST_PING)
+        const sendPing = !lastPing || Date.now() - lastPing >= WAIT_MS_BEFORE_NEXT_PING
+
+        if (sendPing) {
+            openTimer = setTimeout(() => {
+                if (isSubscribed) setIsVisible(true)
+            }, 1000)
+            pingFn().then((success) => {
+                if (isSubscribed) {
+                    setIsSuccess(success)
+                    setIsLoading(false)
+                }
+                // If successful, close notification after one second.
+                if (success) {
+                    localStorage.setItem(LOCAL_STORAGE_LAST_PING, Date.now())
+                    closeTimer = setTimeout(() => {
+                        if (isSubscribed) setIsVisible(false)
+                    }, 1000)
+                }
+            })
+        } else {
+            setIsVisible(false)
+        }
+
+        return () => {
+            isSubscribed = false
+            if (openTimer) clearTimeout(openTimer)
+            if (closeTimer) clearTimeout(closeTimer)
+        }
+    }, [])
+
+    const outcome = getConnectionOutcome(isLoading, isSuccess)
+    const message = getConnectionMessage(isLoading, isSuccess)
+    const animation = !isLoading && isSuccess ? 'FadeOut' : 'FadeIn'
+    const classes = ['Bottom', 'Fixed', 'Centered', outcome, animation]
+
+    return (
+        <Notification classes={classes} visible={isVisible}>
+            <p>{message}</p>
+        </Notification>
+    )
+}

--- a/frontend/src/app/data/index.js
+++ b/frontend/src/app/data/index.js
@@ -1,2 +1,3 @@
 export * from './Match'
 export * from './User'
+export { default as ConnectToServer } from './ConnectToServer'

--- a/frontend/src/app/styles/Main.css
+++ b/frontend/src/app/styles/Main.css
@@ -90,6 +90,14 @@ strong {
 
 /* Utilities */
 
+.Block {
+    display: block;
+}
+
+.Hidden {
+    display: none;
+}
+
 .VerticalCenter {
     /* Center vertically with flexbox */
     display: flex;

--- a/frontend/src/app/ui/Button.stories.tsx
+++ b/frontend/src/app/ui/Button.stories.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { ComponentStory, ComponentMeta } from '@storybook/react'
 import { faCrown, faGhost } from '@fortawesome/free-solid-svg-icons'
 
 import { Button } from './Button'
@@ -7,9 +6,9 @@ import { Button } from './Button'
 export default {
     title: 'User Interface/Button',
     component: Button,
-} as ComponentMeta<typeof Button>
+}
 
-const Template: ComponentStory<typeof Button> = (args) => <Button {...args} />
+const Template = (args) => <Button {...args} />
 
 export const Primary = Template.bind({})
 Primary.args = {

--- a/frontend/src/app/ui/Notification.css
+++ b/frontend/src/app/ui/Notification.css
@@ -1,0 +1,32 @@
+.Notification {
+    box-sizing: border-box;
+    width: 100%;
+    padding: 0 1em;
+    font-size: var(--text-size);
+}
+
+.Notification .CloseHolder {
+    position: relative;
+}
+
+.Notification .Close {
+    position: absolute;
+    right: 1em;
+}
+
+.Notification .Close:hover {
+    cursor: pointer;
+}
+
+.Notification.Fixed {
+    position: absolute;
+}
+
+.Notification.Bottom {
+    bottom: 0;
+    left: 0;
+}
+
+.Notification.Bottom .Close {
+    top: 1em;
+}

--- a/frontend/src/app/ui/Notification.stories.tsx
+++ b/frontend/src/app/ui/Notification.stories.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+
+import { Notification } from './Notification'
+
+export default {
+    title: 'User Interface/Notification',
+    component: Notification,
+}
+
+const Template = (args) => <Notification {...args} />
+
+export const Basic = Template.bind({})
+Basic.args = {
+    visible: true,
+    children: <p>This is a notification!</p>,
+}
+
+export const FixedBottom = Template.bind({})
+FixedBottom.args = {
+    visible: true,
+    classes: ['Fixed', 'Bottom'],
+    children: <p>This is a notification!</p>,
+}

--- a/frontend/src/app/ui/Notification.tsx
+++ b/frontend/src/app/ui/Notification.tsx
@@ -1,0 +1,41 @@
+import React, { useEffect, useState } from 'react'
+import { onEnter } from '../utils'
+
+import './Notification.css'
+
+interface NotificationProps {
+    visible: boolean
+    classes: Array<string>
+    children: React.FC
+}
+
+export function Notification({ visible, classes = [], children }: NotificationProps) {
+    // By default, notification is hidden until set to visible.
+    const [isVisible, setIsVisible] = useState(visible || false)
+    const display = isVisible ? 'Block' : 'Hidden'
+
+    useEffect(() => {
+        setIsVisible(visible)
+    }, [visible])
+
+    return (
+        <div className={`Notification ${classes.join(' ')} ${display}`}>
+            <div className="CloseHolder">
+                <span
+                    className="Close"
+                    role="button"
+                    tabIndex={0}
+                    onClick={() => {
+                        setIsVisible(false)
+                    }}
+                    onKeyDown={onEnter(() => {
+                        setIsVisible(false)
+                    })}
+                >
+                    x
+                </span>
+            </div>
+            {children}
+        </div>
+    )
+}

--- a/frontend/src/app/ui/index.js
+++ b/frontend/src/app/ui/index.js
@@ -1,4 +1,5 @@
 export * from './Button'
 export * from './Error'
+export * from './Notification'
 export * from './User'
 export { default as Logo } from './Logo'

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { Link } from 'react-router-dom'
 
 import { Button, Logo } from '../app/ui'
+import { ConnectToServer } from '../app/data'
 
 import '../app/styles/HomePage.css'
 
@@ -16,6 +17,7 @@ export default function HomePage() {
                     <Button label="Login" primary />
                 </Link>
             </div>
+            <ConnectToServer />
         </div>
     )
 }

--- a/frontend/src/pages/JoinPage.jsx
+++ b/frontend/src/pages/JoinPage.jsx
@@ -5,7 +5,7 @@ import { useCurrentAuthUser, signInUser } from '../app/login'
 import { fetchFromBackend } from '../app/utils'
 import { COMMUNITY_CONFIG } from '../config/communities'
 import { JoinCommunity } from '../app/community'
-import { maybeUpdateUserDetails } from '../app/data'
+import { ConnectToServer, maybeUpdateUserDetails } from '../app/data'
 
 async function doJoin(communityId, uid) {
     const route = `/core/community/${communityId}/join/${uid}`
@@ -30,6 +30,7 @@ export default function JoinPage() {
                 doJoin={doJoin}
                 doLogIn={doLogIn}
             />
+            <ConnectToServer />
         </div>
     )
 }

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -5,7 +5,7 @@ import { faGoogle } from '@fortawesome/free-brands-svg-icons'
 import { faUserNinja } from '@fortawesome/free-solid-svg-icons'
 
 import { CurrentLogin, signInUser, signOutUser, useCurrentAuthUser } from '../app/login'
-import { maybeUpdateUserDetails } from '../app/data'
+import { ConnectToServer, maybeUpdateUserDetails } from '../app/data'
 import { Button, Error, Logo } from '../app/ui'
 
 import '../app/login/Login.css'
@@ -66,6 +66,7 @@ export default function LoginPage() {
                 <CurrentLogin authUser={authUser} doLogOut={doLogOut} />
             </div>
             <MockLoginButton />
+            <ConnectToServer />
         </div>
     )
 }


### PR DESCRIPTION
Since we use Heroku free tier, our production API goes to sleep after ~20m of inactivity.

This component is added to certain pages in order to send a ping to wake up the API when the user arrives. It is only needed on the home page, real login page, and join page. Other pages are not for production use or already send their own API requests on load.