### PR TITLE
Fix Prefect versioning and startup.

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -61,10 +61,12 @@ tasks:
   - name: Storybook
     command: |
       source .bash_aliases
+      source .venv/bin/activate
       ./run.sh storybook
   - name: Prefect
     command: |
       source .bash_aliases
+      source .venv/bin/activate
       ./run.sh prefect-dashboard
   - name: Terminal
     init: |

--- a/pipeline/scripts/register_all_flows.py
+++ b/pipeline/scripts/register_all_flows.py
@@ -11,4 +11,6 @@ FLOWS = [matching_flow]
 if __name__ == "__main__":
     for get_flow in FLOWS:
         flow = get_flow()
-        flow.register(project_name=PROJECT)
+        # Only register a new version if flow metadata has changed
+        flow_hash = flow.serialized_hash()
+        flow.register(project_name=PROJECT, idempotency_key=flow_hash)

--- a/run.sh
+++ b/run.sh
@@ -215,10 +215,12 @@ elif [ "$1" == "prefect-dashboard" ]; then
     echo "[server]" >> prefect.toml
     echo "  [server.ui]" >> prefect.toml
     echo "  apollo_url = \"$(gp url 4200)/graphql\"" >> prefect.toml
-    mkdir ~/.prefect
+    mkdir -p ~/.prefect
     cp prefect.toml ~/.prefect/config.toml
     rm prefect.toml
   fi
+  # Stop Prefect server in case it is already running
+  prefect server stop
   # Set Prefect backend to local server
   prefect backend server
   # Start Prefect services in the background


### PR DESCRIPTION
- Only register new version of Prefect flow if flow metadata changed.
  - Uses [`idempotency_key` and `serialized_hash`](https://github.com/PrefectHQ/prefect/issues/4618).
- Try to stop existing Prefect server before starting a new one, so that `run prefect-dashboard` can be re-run.
- Fix case where Prefect config directory is already created.
- Ensure all terminals activate virtual environment at GitPod startup.