### PR TITLE
Implement attributes backend.

### DIFF
--- a/backend/attributes/__init__.py
+++ b/backend/attributes/__init__.py
@@ -1,0 +1,1 @@
+from backend.attributes.validation import *

--- a/backend/attributes/urls.py
+++ b/backend/attributes/urls.py
@@ -1,8 +1,8 @@
 from django.urls import path
 
-from backend.attributes.views import view_user_intents, view_user_interests
+from backend.attributes.views import view_attribute, view_update_attribute
 
 urlpatterns = [
-    path("user_intents", view_user_intents),
-    path("user_interests", view_user_interests),
+    path("users/<str:uid>/<str:attribute>", view_attribute),
+    path("users/<str:uid>/<str:attribute>/<str:code>", view_update_attribute),
 ]

--- a/backend/attributes/validation.py
+++ b/backend/attributes/validation.py
@@ -1,0 +1,15 @@
+from pipeline.types import Side
+
+VALID_SIDES = {Side.SEEKING.value, Side.GIVING.value}
+
+
+def is_intent_map(d):
+    """Checks whether data is Dict[Side, bool]."""
+    if not isinstance(d, dict):
+        return False
+    for key, val in d.items():
+        if key not in VALID_SIDES:
+            return False
+        if not isinstance(val, bool):
+            return False
+    return True

--- a/backend/attributes/views/__init__.py
+++ b/backend/attributes/views/__init__.py
@@ -1,2 +1,1 @@
-from backend.attributes.views.user_intents import *
-from backend.attributes.views.user_interests import *
+from backend.attributes.views.attribute import *

--- a/backend/attributes/views/attribute.py
+++ b/backend/attributes/views/attribute.py
@@ -1,0 +1,71 @@
+import json
+from json import JSONDecodeError
+from typing import Optional, Tuple
+
+from django.http import JsonResponse
+
+from backend.attributes import is_intent_map
+from backend.utils import format_json, with_db
+
+# Map of attribute ID to a function that checks whether the given data is a
+# valid value for that attribute.
+VALIDATED_ATTRIBUTES = {
+    "interests": lambda d: isinstance(d, bool),
+    "intents": is_intent_map,
+}
+
+CommunityOrError = Tuple[Optional[str], Optional[JsonResponse]]
+
+
+def validate_request(request, attribute: str, method: str) -> CommunityOrError:
+    if request.method != method:
+        err = format_json(status=405, error=f"Only supported for {method}.")
+        return None, err
+    # Query parameter will come from request.GET even on a POST
+    community = getattr(request, "GET", {}).get("community")
+    if attribute not in VALIDATED_ATTRIBUTES:
+        err = format_json(status=400, error=f"Invalid attribute: {attribute}")
+        return None, err
+    if not community:
+        err = format_json(status=400, error="Missing community.")
+        return None, err
+    return community, None
+
+
+@with_db
+def view_attribute(db, request, uid: str, attribute: str):
+    community, err = validate_request(request, attribute, method="GET")
+    if err:
+        return err
+
+    ref = db.reference(f"attributes/{attribute}/{community}/{uid}")
+    raw = ref.get()
+
+    values = []
+    if raw:
+        values = [dict(code=code, data=data) for code, data in raw.items()]
+    return format_json(attributes=values)
+
+
+@with_db
+def view_update_attribute(db, request, uid: str, attribute: str, code: str):
+    community, err = validate_request(request, attribute, method="POST")
+    if err:
+        return err
+
+    raw_update = request.POST.get("update")
+    if not raw_update:
+        return format_json(status=400, error="No update value for attribute.")
+
+    try:
+        update = json.loads(raw_update)
+    except JSONDecodeError:
+        return format_json(status=400, error="Update is not valid JSON.")
+
+    is_valid = VALIDATED_ATTRIBUTES[attribute]
+    if not is_valid(update):
+        return format_json(status=400, error=f"Invalid data for {attribute}.")
+
+    ref = db.reference(f"attributes/{attribute}/{community}/{uid}/{code}")
+    ref.update(update)
+    return format_json(success=True)

--- a/backend/attributes/views/attribute_test.py
+++ b/backend/attributes/views/attribute_test.py
@@ -1,0 +1,218 @@
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from django.test import Client
+
+from backend.testing import assert_response_match, with_mock_db
+from backend.utils import format_json
+
+# Test cases for getting user attributes
+GET_ATTRIBUTE_TESTS = {
+    "basic_interests": {
+        "attribute": "interests",
+        "database": {"hiking": True, "biking": False},
+        "attributes": [
+            {"code": "hiking", "data": True},
+            {"code": "biking", "data": False},
+        ],
+    },
+    "basic_intents": {
+        "attribute": "intents",
+        "database": {
+            "tutoring": {"seeking": True},
+            "shows": {"seeking": False, "giving": True},
+        },
+        "attributes": [
+            {"code": "tutoring", "data": {"seeking": True}},
+            {"code": "shows", "data": {"seeking": False, "giving": True}},
+        ],
+    },
+}
+
+# Test cases for updating user attributes
+UPDATE_ATTRIBUTE_TESTS = {
+    "add_interest": {
+        "attribute": "interests",
+        "code": "hiking",
+        "update": True,
+        "expected": {"success": True},
+        "did_update": True,
+    },
+    "remove_interest": {
+        "attribute": "interests",
+        "code": "biking",
+        "update": False,
+        "expected": {"success": True},
+        "did_update": True,
+    },
+    "invalid_interest_not_bool": {
+        "attribute": "interests",
+        "code": "biking",
+        "update": 12,  # Not a boolean
+        "expected": {"status": 400, "error": "Invalid data for interests."},
+        "did_update": False,
+    },
+    "add_intent": {
+        "attribute": "intents",
+        "code": "tutoring",
+        "update": {"seeking": True},
+        "expected": {"success": True},
+        "did_update": True,
+    },
+    "remove_intent": {
+        "attribute": "intents",
+        "code": "tutoring",
+        # Note: This unit test mocks the database, but the real Firebase will
+        # merge update data with existing data, so if the user already has
+        # {"giving": True} for this intent, this update will add
+        # {"seeking": False} without deleting or modifiying the giving key
+        "update": {"seeking": False},
+        "expected": {"success": True},
+        "did_update": True,
+    },
+    "invalid_intent_not_dict": {
+        "attribute": "intents",
+        "code": "tutoring",
+        "update": True,  # Not a dictionary
+        "expected": {"status": 400, "error": "Invalid data for intents."},
+        "did_update": False,
+    },
+    "invalid_intent_not_dict_of_bool": {
+        "attribute": "intents",
+        "code": "tutoring",
+        "update": {"seeking": 12},  # Not a dictionary of booleans
+        "expected": {"status": 400, "error": "Invalid data for intents."},
+        "did_update": False,
+    },
+    "invalid_intent_invalid_side": {
+        "attribute": "intents",
+        "code": "tutoring",
+        "update": {"providing": True},  # Not a dictionary of side keys
+        "expected": {"status": 400, "error": "Invalid data for intents."},
+        "did_update": False,
+    },
+}
+
+
+@with_mock_db
+@pytest.mark.parametrize("test_key", GET_ATTRIBUTE_TESTS.keys())
+def test_get_attribute(mock_db, test_key):
+    test_data = GET_ATTRIBUTE_TESTS[test_key]
+    attribute = test_data["attribute"]
+    mock_get = MagicMock(return_value=test_data["database"])
+    mock_db.reference(f"attributes/{attribute}/test/andrew").get = mock_get
+
+    c = Client()
+    community = "test"
+    uid = "andrew"
+    actual = c.get(f"/attributes/users/{uid}/{attribute}?community={community}")
+
+    expected = format_json(attributes=test_data["attributes"])
+    assert_response_match(actual, expected)
+    mock_get.assert_called_once_with()
+
+
+@with_mock_db
+def test_get_invalid_attribute(mock_db):
+    c = Client()
+    community = "test"
+    uid = "andrew"
+    actual = c.get(f"/attributes/users/{uid}/hype-factor?community={community}")
+
+    expected = format_json(status=405, error="Invalid attribute: hype-factor")
+    assert_response_match(actual, expected)
+    mock_db.assert_not_called()
+
+
+@with_mock_db
+def test_get_missing_community(mock_db):
+    c = Client()
+    uid = "andrew"
+    actual = c.get(f"/attributes/users/{uid}/interests")
+
+    expected = format_json(status=405, error="Missing community.")
+    assert_response_match(actual, expected)
+    mock_db.assert_not_called()
+
+
+@with_mock_db
+def test_get_missing_user(mock_db):
+    mock_get = MagicMock(return_value=None)
+    mock_db.reference(f"attributes/interests/test/andrew").get = mock_get
+
+    c = Client()
+    community = "test"
+    uid = "andrew"
+    actual = c.get(f"/attributes/users/{uid}/interests?community={community}")
+
+    expected = format_json(attributes=[])
+    assert_response_match(actual, expected)
+    mock_get.assert_called_once_with()
+
+
+@with_mock_db
+@pytest.mark.parametrize("test_key", UPDATE_ATTRIBUTE_TESTS.keys())
+def test_update_attribute(mock_db, test_key):
+    test_data = UPDATE_ATTRIBUTE_TESTS[test_key]
+    attribute = test_data["attribute"]
+    mock_update = MagicMock()
+    ref = f"attributes/{attribute}/test/andrew"
+    mock_db.reference(ref).update = mock_update
+
+    c = Client()
+    community = "test"
+    uid = "andrew"
+    code = test_data["code"]
+    url = f"/attributes/users/{uid}/{attribute}/{code}?community={community}"
+    data = {"update": json.dumps(test_data["update"])}
+    actual = c.post(url, data)
+
+    expected = format_json(**test_data["expected"])
+    assert_response_match(actual, expected)
+    if test_data["did_update"]:
+        mock_update.assert_called_once_with(test_data["update"])
+    else:
+        mock_update.assert_not_called()
+
+
+@with_mock_db
+def test_update_invalid_attribute(mock_db):
+    c = Client()
+    community = "test"
+    uid = "andrew"
+    actual = c.post(f"/attributes/users/{uid}/hype/123?community={community}")
+
+    expected = format_json(status=405, error="Invalid attribute: hype")
+    assert_response_match(actual, expected)
+    mock_db.assert_not_called()
+
+
+@with_mock_db
+def test_update_missing_community(mock_db):
+    c = Client()
+    uid = "andrew"
+    actual = c.post(f"/attributes/users/{uid}/interests/hiking")
+
+    expected = format_json(status=405, error="Missing community.")
+    assert_response_match(actual, expected)
+    mock_db.assert_not_called()
+
+
+@with_mock_db
+def test_update_missing_user(mock_db):
+    mock_update = MagicMock()
+    ref = f"attributes/interests/test/andrew/hiking"
+    mock_db.reference(ref).update = mock_update
+
+    c = Client()
+    community = "test"
+    uid = "andrew"
+    url = f"/attributes/users/{uid}/interests/hiking?community={community}"
+    data = {"update": json.dumps(True)}
+    actual = c.post(url, data)
+
+    # There is no check for missing users, so the update will be created anyway
+    expected = format_json(success=True)
+    assert_response_match(actual, expected)
+    mock_update.assert_called_once_with(True)

--- a/backend/attributes/views/user_intents.py
+++ b/backend/attributes/views/user_intents.py
@@ -1,5 +1,0 @@
-from django.http import HttpResponse
-
-
-def view_user_intents(request):
-    return HttpResponse(status=200)

--- a/backend/attributes/views/user_interests.py
+++ b/backend/attributes/views/user_interests.py
@@ -1,5 +1,0 @@
-from django.http import HttpResponse
-
-
-def view_user_interests(request):
-    return HttpResponse(status=200)


### PR DESCRIPTION
## New Endpoints

### Get User Interests

Get all interests for a user, including interests they turned off (`false`).

**Endpoint:** `GET users/:uid/interests?community=:community`

**Example Response:**

```json
{
  "attributes": [
    {
      "code": "hiking",
      "data": true,
    },
    {
      "code": "biking",
      "data": false,
    }
  ]
}
```

### Get User Intents

Get all intents for a user, including intents they turned off (`false`). Users might be both giving and seeking the same intent.

**Endpoint:** `GET users/:uid/intents?community=:community`

**Example Response:**

```json
{
  "attributes": [
    {
      "code": "tutoring",
      "data": {
        "seeking": true
      },
    },
    {
      "code": "shows",
      "data": {
        "seeking": false,
        "giving": true
      },
    }
  ]
}
```

### Update User Interests

Update an interest for a user by its code. Use `true` to turn on an interest and `false` to turn it off.

**Endpoint:** `POST users/:uid/interests/:code?community=:community`

**Example Body:**

```json
{
  "update": true
}
```

### Update User Intents

Update an intent for a user by its code and side(s). Use `true` to turn on an intent side and `false` to turn it off.

**Endpoint:** `POST users/:uid/interests/:code?community=:community`

**Example Body:**

```json
{
  "update": {
    "seeking": false,
    "giving": true
  }
}
```
