### PR TITLE
Migrate core API to Django Ninja.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,12 @@ An app to meet new people in your community.
 
 The UI and API automatically update when you make changes to source files.
 
-| Command    | Description                |
-| ---------- | -------------------------- |
-| `run ui`   | Open frontend UI in a tab. |
-| `run api`  | Open backend API in a tab. |
-| `run book` | Open Storybook in a tab.   |
+| Command        | Description                      |
+| -------------- | -------------------------------- |
+| `run ui`       | Open frontend UI in a tab.       |
+| `run api`      | Open backend API in a tab.       |
+| `run api-docs` | Open API documentation in a tab. |
+| `run book`     | Open Storybook in a tab.         |
 
 ### Common Pipeline Commands
 

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -1,8 +1,9 @@
 from django.urls import path
+from ninja import Router
 
-from backend.core.views import view_join_community, view_user
+from backend.core.views.community import router as community_router
+from backend.core.views.user import router as user_router
 
-urlpatterns = [
-    path("user/<str:uid>", view_user),
-    path("community/<str:community>/join/<str:uid>", view_join_community),
-]
+router = Router()
+router.add_router("/community", community_router)
+router.add_router("/user", user_router)

--- a/backend/core/views/__init__.py
+++ b/backend/core/views/__init__.py
@@ -1,2 +1,0 @@
-from backend.core.views.community import *
-from backend.core.views.user import *

--- a/backend/core/views/community.py
+++ b/backend/core/views/community.py
@@ -1,12 +1,17 @@
-from backend.utils import SERVER_TIMESTAMP, format_json, with_db
+from ninja import Router
+
+from backend.utils import SERVER_TIMESTAMP, format_json, get_db
+
+router = Router()
 
 
-@with_db
-def view_join_community(db, request, community: str, uid: str):
+@router.post("/{community}/join/{uid}")
+def view_join_community(request, community: str, uid: str):
     """Add a given user to a given community."""
     if request.method != "POST":
         return format_json(status=405, error="Only supported for POST.")
 
+    db = get_db()
     user = db.reference(f"users/{uid}").get()
     if not user:
         return format_json(status=404, error=f"No user for ID: {uid}")

--- a/backend/core/views/user.py
+++ b/backend/core/views/user.py
@@ -1,9 +1,14 @@
-from backend.utils import format_json, with_db
+from ninja import Router
+
+from backend.utils import format_json, get_db
+
+router = Router()
 
 
-@with_db
-def view_user(db, request, uid: str):
+@router.get("/{uid}")
+def view_user(request, uid: str):
     """Gets a user's profile data by their user ID."""
+    db = get_db()
     data = db.reference(f"users/{uid}").get()
     if not data:
         return format_json(success=False, message=f"No user for ID: {uid}")

--- a/backend/core/views/user_test.py
+++ b/backend/core/views/user_test.py
@@ -13,7 +13,7 @@ def test_get_user_by_id(mock_db):
 
     c = Client()
     uid = "erik"
-    actual = c.post(f"/core/user/{uid}")
+    actual = c.get(f"/core/user/{uid}")
 
     expected = format_json(data={"displayName": "Erik"})
     assert_response_match(actual, expected)
@@ -27,7 +27,7 @@ def test_no_user_found(mock_db):
 
     c = Client()
     uid = "derik"
-    actual = c.post(f"/core/user/{uid}")
+    actual = c.get(f"/core/user/{uid}")
 
     expected = format_json(success=False, message="No user for ID: derik")
     assert_response_match(actual, expected)

--- a/backend/server/urls.py
+++ b/backend/server/urls.py
@@ -1,11 +1,17 @@
 from django.urls import include, path
+from ninja import NinjaAPI
+
+from backend.core.urls import router as core_router
 
 from . import views
 
+api = NinjaAPI()
+api.add_router("/core", core_router)
+
 urlpatterns = [
     path("", views.hello),
+    path("", api.urls),
     path("attributes/", include("backend.attributes.urls")),
     path("chat/", include("backend.chat.urls")),
-    path("core/", include("backend.core.urls")),
     path("ratings/", include("backend.ratings.urls")),
 ]

--- a/backend/utils/firebase.py
+++ b/backend/utils/firebase.py
@@ -45,3 +45,8 @@ def with_db(func: Callable):
         return func(db, *args, **kwargs)
 
     return wrapper
+
+
+def get_db():
+    """Returns the Firebase database."""
+    return db

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ dataclasses==0.6
 Django==3.2.8
 django-cors-headers==3.10.0
 django-environ==0.8.0
+django-ninja==0.18.0
 firebase-admin==5.2.0
 gunicorn==20.1.0
 pandas==1.3.5

--- a/run.sh
+++ b/run.sh
@@ -17,10 +17,13 @@ set_prefect_secrets () {
 }
 
 open_port_in_tab () {
+  PORT=$1
+  RELATIVE_URL=$2
   if command -v gp &> /dev/null; then
-    gp preview $(gp url "$1")
+    BASE_URL=$(gp url "$PORT")
+    gp preview "$BASE_URL$RELATIVE_URL"
   else
-    open "http://localhost:$1"
+    open "http://localhost:$PORT"
   fi
 }
 
@@ -35,6 +38,10 @@ elif [ "$1" == "book" ]; then
 elif [ "$1" == "api" ]; then
   # Open backend API in a tab
   open_port_in_tab "$BACKEND_PORT"
+
+elif [ "$1" == "api-docs" ]; then
+  # Open backend API in a tab
+  open_port_in_tab "$BACKEND_PORT" "/docs"
 
 elif [ "$1" == "dash" ]; then
   # Open Prefect dashboard in a tab


### PR DESCRIPTION
We wanted to add a documentation tool to our API, but generators for popular tools like OpenAI (Swagger) assume more Django model usage than we currently need.

[Django Ninja](https://github.com/vitalik/django-ninja) seems like a fast and lightweight API framework that matches the OpenAPI specification, so we can use it for simple endpoint building and for automatic documentation!

Use `run api-docs` to launch the docs page, which is served by our API. You can see which endpoints are available and try out example requests to view the responses.

This PR serves as a basic example of migrating from a Django endpoint to a Ninja endpoint.

![Screen Shot 2022-06-23 at 11 54 33 PM](https://user-images.githubusercontent.com/11896652/175480058-1e6065e1-99a7-470e-b8a9-7705fb7b8862.png)
