### PR TITLE
Add more intents for SDS and demo communities.

### DIFF
--- a/frontend/src/config/communities.tsx
+++ b/frontend/src/config/communities.tsx
@@ -16,8 +16,8 @@ export const COMMUNITY_CONFIG: CommunityConfig = {
         id: 'demo',
         name: 'Demo Community',
         intents: [
-            { code: 'tutoring', name: 'Tutoring' },
-            { code: 'tv-movie-recs', name: 'TV/Movie Recommendations' },
+            { code: 'tutoring-math', name: 'Get tutoring in math' },
+            { code: 'watch-recs', name: 'Get show and movie recommendations' },
         ],
         interests: [
             { code: 'running', name: 'Running' },
@@ -28,7 +28,11 @@ export const COMMUNITY_CONFIG: CommunityConfig = {
     sds: {
         id: 'sds',
         name: 'Scarlet Data Studio',
-        intents: [],
+        intents: [
+            { code: 'tech-careers', name: 'Learn about careers in technology' },
+            { code: 'involve-iit', name: 'Get more involved at Illinois Tech' },
+            { code: 'watch-recs', name: 'Get show and movie recommendations' },
+        ],
         interests: [],
     },
     esi: {


### PR DESCRIPTION
## Intents

Intents are areas where Butterfly members can support each other.

For each intent, you can select it as something you want, something you can help with, or both!

## Display Names

The display name of an intent should start with a verb and fit into this format:

- "I want to X"
- "I can help X"

For example:

- "I want to learn about careers in technology"
- "I can help learn about careers in technology"

Note: If we need to show an intent in sentence form, we have to lowercase the first letter of the display name.

You can see an example of how the intents will be rendered on issue #92.

## Configuration

Each community can customize which intents it has, in order to give members more relevant choices.

Currently, this file contains all the settings for each community:

```
frontend/src/config/communities.tsx
```

We can edit this file to add more intents.