### PR TITLE
Implement GET and POST endpoints for blocking users.

### DIFF
--- a/backend/chat/urls.py
+++ b/backend/chat/urls.py
@@ -4,4 +4,4 @@ from ninja import Router
 from backend.chat.views.block_user import router as block_user_router
 
 router = Router()
-router.add_router("/block", block_user_router)
+router.add_router("", block_user_router)

--- a/backend/chat/views/block_user.py
+++ b/backend/chat/views/block_user.py
@@ -1,10 +1,30 @@
 from ninja import Router
 
-from backend.utils import format_json
+from backend.utils import SERVER_TIMESTAMP, format_json, get_db
 
 router = Router()
 
 
-@router.post("/user/{uid_from}/{uid_to}")
-def update_blocked_user(request, uid_from: str, uid_to: str):
-    return format_json(message="Not yet implemented.")
+@router.get("/block/user/{uid_from}")
+def get_blocked_users_for_user(request, uid_from: str):
+    db = get_db()
+    ref = db.reference(f"safety/blocks/{uid_from}")
+    raw = ref.get()
+    blocked_users = []
+    if raw:
+        blocked_users = [{"uid": uid, **data} for uid, data in raw.items()]
+    return format_json(blocks=blocked_users)
+
+
+@router.post("/block/user/{uid_from}/{uid_to}/{blocked}")
+def update_blocked_user(request, uid_from: str, uid_to: str, blocked: bool):
+    # Note: Blocking a user will block them across all communities.
+    data = {
+        "blocked": blocked,
+        "updated": SERVER_TIMESTAMP,
+    }
+    db = get_db()
+    ref = db.reference(f"safety/blocks/{uid_from}")
+    ref.update({uid_to: data})
+    status = "blocked" if blocked else "unblocked"
+    return format_json(message=f"User is now {status}.")

--- a/backend/chat/views/block_user_test.py
+++ b/backend/chat/views/block_user_test.py
@@ -1,16 +1,103 @@
 from unittest.mock import MagicMock
 
+from django.http import HttpResponseNotFound
 from django.test import Client
 
-from backend.testing import assert_response_match
-from backend.utils import format_json
+from backend.testing import assert_response_match, with_mock_db
+from backend.utils import SERVER_TIMESTAMP, format_json
 
 
-def test_block_user():
+@with_mock_db
+def test_get_blocked_users_for_user(mock_db):
+    mock_get = MagicMock(
+        return_value={
+            "shrek": {"blocked": True, "updated": 1},
+            "dragon": {"blocked": False, "updated": 2},
+        }
+    )
+    mock_db.reference("trust/blocks/donkey").get = mock_get
+
+    c = Client()
+    uid_from = "donkey"
+    actual = c.get(f"/chat/block/user/{uid_from}")
+
+    expected = format_json(
+        blocks=[
+            {"uid": "shrek", "blocked": True, "updated": 1},
+            {"uid": "dragon", "blocked": False, "updated": 2},
+        ]
+    )
+    assert_response_match(actual, expected)
+    mock_get.assert_called_once_with()
+
+
+@with_mock_db
+def test_get_no_blocked_users(mock_db):
+    mock_get = MagicMock(return_value=None)
+    mock_db.reference("trust/blocks/shrek").get = mock_get
+
+    c = Client()
+    uid_from = "shrek"
+    actual = c.get(f"/chat/block/user/{uid_from}")
+
+    expected = format_json(blocks=[])
+    assert_response_match(actual, expected)
+    mock_get.assert_called_once_with()
+
+
+@with_mock_db
+def test_block_user(mock_db):
+    mock_update = MagicMock()
+    mock_db.reference("trust/blocks/donkey").update = mock_update
+
     c = Client()
     uid_from = "donkey"
     uid_to = "shrek"
-    actual = c.post(f"/chat/block/user/{uid_from}/{uid_to}")
+    actual = c.post(f"/chat/block/user/{uid_from}/{uid_to}/true")
 
-    expected = format_json(message="Not yet implemented.")
+    expected = format_json(message="User is now blocked.")
     assert_response_match(actual, expected)
+    mock_update.assert_called_once_with(
+        {
+            "shrek": {
+                "blocked": True,
+                "updated": SERVER_TIMESTAMP,
+            }
+        }
+    )
+
+
+@with_mock_db
+def test_unblock_user(mock_db):
+    mock_update = MagicMock()
+    mock_db.reference("trust/blocks/donkey").update = mock_update
+
+    c = Client()
+    uid_from = "donkey"
+    uid_to = "shrek"
+    actual = c.post(f"/chat/block/user/{uid_from}/{uid_to}/false")
+
+    expected = format_json(message="User is now unblocked.")
+    assert_response_match(actual, expected)
+    mock_update.assert_called_once_with(
+        {
+            "shrek": {
+                "blocked": False,
+                "updated": SERVER_TIMESTAMP,
+            }
+        }
+    )
+
+
+@with_mock_db
+def test_bad_block_url(mock_db):
+    mock_update = MagicMock()
+    mock_db.reference("trust/blocks/donkey").update = mock_update
+
+    c = Client()
+    uid_from = ""
+    uid_to = ""
+    actual = c.post(f"/chat/block/user/{uid_from}/{uid_to}/true")
+
+    assert isinstance(actual, HttpResponseNotFound)
+    mock_update.assert_not_called()


### PR DESCRIPTION
## Summary

FYI @sprihajha @gracesopha here are the API endpoints you can send requests to for feature #90.

Implements endpoints to:

- Get blocked users for a user
- Update blocked user for a user

Notes:

- When you block a user, they are blocked across all communities
- Blocks are single-directional: the from user blocks the to user
- The response for blocked users also includes users who may have been unblocked

## Endpoints

![Screen Shot 2022-06-27 at 2 39 03 PM](https://user-images.githubusercontent.com/11896652/176040466-94d4176a-e535-450e-96d0-316e5fada1c0.png)

## Example Usage

In React, get blocked users for a user:

```jsx
const uid = // user ID you are checking for
const [res, err] = useBackendFetchJson({
  route: `/chat/block/user/${uid}`
})
console.log(res?.blocks)
// [
//    { "uid": "abcd1234", "blocked": true, "updated": 1656366431508 },
//    { "uid": "efgh5678", "blocked": false, "updated": 1656366460051 },
// ]
```

In React, block a user:

```jsx
// Get blocked users for a user
const uid = // user ID you are checking for
const blockUser = // user ID you are blocking
const [res, err] = useBackendFetchJson({
  route: `/chat/block/user/${uid}/${blockUser}/true`,
  method: 'POST',
})
console.log(res?.message)
// "User is now blocked."
```