### PR TITLE
Move community into request URL for attributes endpoints.

### DIFF
--- a/backend/attributes/views/attribute_test.py
+++ b/backend/attributes/views/attribute_test.py
@@ -106,7 +106,7 @@ def test_get_attribute(mock_db, test_key):
     c = Client()
     community = "test"
     uid = "andrew"
-    actual = c.get(f"/attributes/users/{uid}/{attribute}?community={community}")
+    actual = c.get(f"/attributes/community/{community}/users/{uid}/{attribute}")
 
     expected = format_json(attributes=test_data["attributes"])
     assert_response_match(actual, expected)
@@ -118,20 +118,9 @@ def test_get_invalid_attribute(mock_db):
     c = Client()
     community = "test"
     uid = "andrew"
-    actual = c.get(f"/attributes/users/{uid}/hype-factor?community={community}")
+    actual = c.get(f"/attributes/community/{community}/users/{uid}/hype-factor")
 
     expected = format_json(status=405, error="Invalid attribute: hype-factor")
-    assert_response_match(actual, expected)
-    mock_db.assert_not_called()
-
-
-@with_mock_db
-def test_get_missing_community(mock_db):
-    c = Client()
-    uid = "andrew"
-    actual = c.get(f"/attributes/users/{uid}/interests")
-
-    expected = format_json(status=405, error="Missing community.")
     assert_response_match(actual, expected)
     mock_db.assert_not_called()
 
@@ -144,7 +133,7 @@ def test_get_missing_user(mock_db):
     c = Client()
     community = "test"
     uid = "andrew"
-    actual = c.get(f"/attributes/users/{uid}/interests?community={community}")
+    actual = c.get(f"/attributes/community/{community}/users/{uid}/interests")
 
     expected = format_json(attributes=[])
     assert_response_match(actual, expected)
@@ -164,7 +153,7 @@ def test_update_attribute(mock_db, test_key):
     community = "test"
     uid = "andrew"
     code = test_data["code"]
-    url = f"/attributes/users/{uid}/{attribute}/{code}?community={community}"
+    url = f"/attributes/community/{community}/users/{uid}/{attribute}/{code}"
     data = {"update": json.dumps(test_data["update"])}
     actual = c.post(url, data)
 
@@ -181,20 +170,9 @@ def test_update_invalid_attribute(mock_db):
     c = Client()
     community = "test"
     uid = "andrew"
-    actual = c.post(f"/attributes/users/{uid}/hype/123?community={community}")
+    actual = c.post(f"/attributes/community/{community}/users/{uid}/hype/123")
 
     expected = format_json(status=405, error="Invalid attribute: hype")
-    assert_response_match(actual, expected)
-    mock_db.assert_not_called()
-
-
-@with_mock_db
-def test_update_missing_community(mock_db):
-    c = Client()
-    uid = "andrew"
-    actual = c.post(f"/attributes/users/{uid}/interests/hiking")
-
-    expected = format_json(status=405, error="Missing community.")
     assert_response_match(actual, expected)
     mock_db.assert_not_called()
 
@@ -208,7 +186,7 @@ def test_update_missing_user(mock_db):
     c = Client()
     community = "test"
     uid = "andrew"
-    url = f"/attributes/users/{uid}/interests/hiking?community={community}"
+    url = f"/attributes/community/{community}/users/{uid}/interests/hiking"
     data = {"update": json.dumps(True)}
     actual = c.post(url, data)
 


### PR DESCRIPTION
## Summary

FYI @mflowers1395 @gravediggaz666 @vingkan here are the API endpoints you can send requests to for features #91 and #92.

- Fixes attributes endpoints to include community in the request URL path.

## Endpoints

Use `run api-docs` to launch the API documentation in GitPod and then open these endpoints for more information.

<img width="1039" alt="Screen Shot 2022-06-27 at 5 59 10 PM" src="https://user-images.githubusercontent.com/11896652/176064373-32d597c5-fb99-48fa-b854-dbd4ca93062c.png">

## Example Usage

In React, get a user's interests:

```jsx
const community = '...' // Community the user is editing
const uid = '...' // ID of the user editing their profile
const [res, err] = useBackendFetchJson({
  route: `/attributes/community/${community}/user/${uid}/interests`
})
console.log(res?.attributes)
// [
//    { code: "hiking", data: true },
//    { code: "biking", data: false },
// ]
```

Follow a similar format to get a user's intents.

In React, update a user interest:

```jsx
const community = '...' // Community the user is editing
const uid = '...' // ID of the user editing their profile
const attributeCode = 'hiking' // Code of attribute to update
const attributeUpdate = { update: true } // New value for the attribute
const [res, err] = useBackendFetchJson({
  route: `/attributes/community/${community}/user/${uid}/interests/${attributeCode}`,
  method: 'POST',
  body: JSON.parse(attributeUpdate),
})
console.log(res?.success)
// true
```

Follow a similar format to update a user intent.