### PR TITLE
Gitignore package files in the root directory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@ frontend/.env.firebase
 credentials.json
 prefect-credentials.json
 
+# Ignore these files in the root folder, only valid in the /frontend folder
+package.json
+package-lock.json
+
 # Node
 # Source: https://github.com/github/gitignore/blob/main/Node.gitignore
 


### PR DESCRIPTION
To avoid any confusion on #157 due to a new `package-lock.json` file being created in the root directory.