### PR TITLE
Add configuration for pytest extension in GitPod VSCode.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "python.testing.unittestEnabled": false,
+  "python.testing.pytestEnabled": true,
+  "python.testing.pytestArgs": ["-vv"]
+}


### PR DESCRIPTION
## Summary

Fixes #231. The run/debug tab still does not work with our project, but now you can use the testing tab to set breakpoints and run tests.

Adds VSCode settings to allow using the testing extension in the GitPod VSCode editor.

The alternative is to use the approach in #233, but it would require changes to all test files and provides the same functionality as the testing extension with this pull request.

The caveat is that the testing extension does not pick up scripts, only tests. But I think that is a reasonable compromise, because scripts and pipelines should be made up of components that we can test and debug at the unit or integration test level.

## Usage

1. Go to the testing extension on the left sidebar of the GitPod VSCode editor (has a test tube/flask icon)
2. Find the test or module of tests you want to run
3. Click the run or run/debug icon next to the test to run the test
4. View the results
5. Click the file icon next to the test to open that test file/method in your editor
6. Set a breakpoint by clicking the file gutter next to the line number
7. Run the tests again to see the debug information from your breakpoint(s)

## Screenshots

Example of a failed test:

<img width="1440" alt="Screen Shot 2022-07-03 at 5 46 25 PM" src="https://user-images.githubusercontent.com/11896652/177063937-4b0c0920-5230-486b-bb60-97466a83b9fb.png">

Example of a passed test:

<img width="1439" alt="Screen Shot 2022-07-03 at 5 47 18 PM" src="https://user-images.githubusercontent.com/11896652/177063947-f98f36f9-3aac-4fa8-86ad-13ecb9e211ff.png">

Example with breakpoint:

<img width="1439" alt="Screen Shot 2022-07-03 at 5 52 03 PM" src="https://user-images.githubusercontent.com/11896652/177064094-b93da25a-93f1-4e5e-8438-2a3fe619e293.png">
