### PR TITLE
Refactor all chats page to send all requests to Firebase instead of API.

### DIFF
--- a/frontend/src/app/data/Match.js
+++ b/frontend/src/app/data/Match.js
@@ -3,7 +3,7 @@ import { equalTo, getDatabase, onValue, orderByChild, query, ref } from 'firebas
 
 import { DB_PATH } from '../constants'
 import { COMMUNITY_CONFIG } from '../../config/communities'
-import { useGetManyUserData } from './User'
+import { getUserData, useGetManyUserData } from './User'
 
 /*
  * Hook to get community matches for a user.
@@ -53,6 +53,7 @@ export function useGetManyMatchData(userId, communityIdMap) {
     const [communityMatches, setCommunityMatches] = useState({})
     // Try to fetch new matches whenever the input updates
     useEffect(() => {
+        if (!userId) return
         // Filter out community IDs that were already fetched
         Object.keys(communityIdMap)
             .filter((k) => !(k in communityMatches))
@@ -79,11 +80,12 @@ export function useGetManyMatchData(userId, communityIdMap) {
 
 /*
  * Hook to get all of a user's matches across al of their communities.
+ * Fetches from Firebase to avoid dependency on API, so user must be logged in.
  */
 export function useGetAllUserMatches(uid) {
-    const myUser = useGetManyUserData({ [uid]: true })?.[uid]
-    const myCommunities = myUser?.communities || {}
-    const matchesByCommunity = useGetManyMatchData(uid, myCommunities)
+    const user = useGetManyUserData({ [uid]: true }, getUserData)?.[uid]
+    const communities = user?.communities || {}
+    const matchesByCommunity = useGetManyMatchData(uid, communities)
     // Combine matches from all communities into one array, with community data
     const matches = Object.values(matchesByCommunity)
         .reduce((arr, val) => [...arr, ...val], [])

--- a/frontend/src/app/data/User.js
+++ b/frontend/src/app/data/User.js
@@ -35,14 +35,22 @@ export function getUserData(userId) {
     })
 }
 
-export function useGetManyUserData(userIdMap) {
+/*
+ * Hook to get data for many users.
+ * @param userIdMap: map of user IDs to get.
+ * @param doFetch: async or promise function to get a user by user ID.
+ * @returns map of user IDs to user data.
+ */
+export function useGetManyUserData(userIdMap, doFetch = fetchUserData) {
     const [userDetails, setUserDetails] = useState({})
     // Try to fetch new users whenever the input updates
     useEffect(() => {
         // Filter out user IDs that were already fetched
         Object.keys(userIdMap)
-            .filter((k) => !(k in userDetails))
-            .map(fetchUserData)
+            // Annoyingly, undefined values get turned into a string when used
+            // as a dynamic map key, so we have to add this check:
+            .filter((k) => k !== 'undefined' && !(k in userDetails))
+            .map(doFetch)
             .forEach((promise) => {
                 promise
                     .then((userData) => {

--- a/frontend/src/pages/AllChatsPage.jsx
+++ b/frontend/src/pages/AllChatsPage.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { Link } from 'react-router-dom'
 
 import { useCurrentAuthUser } from '../app/login'
-import { useGetManyUserData, useGetAllUserMatches } from '../app/data'
+import { getUserData, useGetManyUserData, useGetAllUserMatches } from '../app/data'
 import { ChatPreview } from '../app/inbox'
 
 export default function AllChatsPage() {
@@ -15,7 +15,7 @@ export default function AllChatsPage() {
         }),
         {}
     )
-    const matchedUsers = useGetManyUserData(matchedUserIds)
+    const matchedUsers = useGetManyUserData(matchedUserIds, getUserData)
 
     const matchEls =
         matches.length > 0 ? (


### PR DESCRIPTION
This should improve the load time of the all chats page, since it will not have to wait for the API to become active.

There are two hooks on the all chats page that were sending requests to the API:

- `useGetAllUserMatches()` is only used by the all chats page, so this has been changed to always fetch from Firebase.
- `useGetManyUserData()` is used on multiple pages, so it now has an optional argument to inject a fetch function, so that ti fetches from Firebase on the all chats page, but from the API by default.
