### PR TITLE
Simplify match metadata with shared attribute fields

### DIFF
--- a/frontend/src/app/types/ChatData.tsx
+++ b/frontend/src/app/types/ChatData.tsx
@@ -1,5 +1,6 @@
 import { UserData } from './UserData'
 
+// Keep this in sync with: pipeline/types/match_metadata.py
 export interface ChatData {
     // ID for the match this chat is for, release tag plus match key
     id: string
@@ -22,5 +23,15 @@ export interface ChatData {
         generator?: string
         score?: number
         commonLetters?: Array<string>
+        interests?: Array<string>
+        intents?: Array<{
+            code: string
+            giver: string
+            seeker: string
+        }>
+        availability?: Array<{
+            day: string
+            hour: number
+        }>
     }
 }

--- a/pipeline/types/match_metadata.py
+++ b/pipeline/types/match_metadata.py
@@ -35,15 +35,27 @@ class MatchMetadata:
     score: float = 0
     # Letters in common in the names of matched users
     commonLetters: List[str] = field(default_factory=list)
+    # Codes of interests relevant to this match
+    interests: List[InterestCode] = field(default_factory=list)
+    # Information about the intents relevant to this match
+    intents: List[IntentMatch] = field(default_factory=list)
+    # Days/times when matched users are both available
+    availability: List[Availability] = field(default_factory=list)
     # Codes of interests shared between the matched users
+    # TODO(#259): Deprecate this field, use `interests` instead
     commonInterests: List[InterestCode] = field(default_factory=list)
     # Similar to commonInterests, but where the interests are rare
+    # TODO(#259): Deprecate this field, use `interests` instead
     rareInterests: List[InterestCode] = field(default_factory=list)
     # Information about the compatible intents between the matched users
+    # TODO(#259): Deprecate this field, use `intents` instead
     matchingIntents: List[IntentMatch] = field(default_factory=list)
     # Similar to matchingIntents, but where the intent is rare
+    # TODO(#259): Deprecate this field, use `intents` instead
     rareIntents: List[IntentMatch] = field(default_factory=list)
     # Days/times when matched users are both available
+    # TODO(#259): Deprecate this field, use `availability` instead
     matchingAvailability: List[Availability] = field(default_factory=list)
     # Similar to matchingAvailability, but where availability is limited
+    # TODO(#259): Deprecate this field, use `availability` instead
     limitedAvailability: List[Availability] = field(default_factory=list)

--- a/pipeline/types/match_metadata.py
+++ b/pipeline/types/match_metadata.py
@@ -13,6 +13,8 @@ class MatchMetadata:
     """
     Schema to hold additional information about a match.
 
+    Keep this in sync with: frontend/src/app/types/ChatData.tsx
+
     Use cases:
     - Additional information from the generator that proposed the match
     - Information needed to rank a proposed match


### PR DESCRIPTION
Closes #258.

The reason we are not deleting the old fields is because other developers might still be using them. After all the generators are implemented, we can refactor to use the new fields and then delete the old fields. That cleanup task is #259.