### PR TITLE
Connect community selector to edit profile page

### DIFF
--- a/frontend/src/app/community/Selector.stories.tsx
+++ b/frontend/src/app/community/Selector.stories.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+
+import { CommunitySelector } from './Selector'
+
+export default {
+    title: 'Community/SelectCommunity',
+    component: CommunitySelector,
+}
+
+const Template = (args) => <CommunitySelector {...args} />
+
+export const NoCommunities = Template.bind({})
+NoCommunities.args = {}
+
+export const SomeCommunitiesNothingSelected = Template.bind({})
+SomeCommunitiesNothingSelected.args = {
+    communities: [
+        { id: 'a', name: 'Community A' },
+        { id: 'b', name: 'Community B' },
+        { id: 'c', name: 'Community C' },
+    ],
+}
+
+export const SelectedCommunity = Template.bind({})
+SelectedCommunity.args = {
+    communities: [
+        { id: 'a', name: 'Community A' },
+        { id: 'b', name: 'Community B' },
+        { id: 'c', name: 'Community C' },
+    ],
+    selected: 'b',
+}

--- a/frontend/src/app/community/Selector.tsx
+++ b/frontend/src/app/community/Selector.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+
+import { CommunityData } from '../../config/communities'
+
+export interface CommunitySelectorProps {
+    communities: Array<CommunityData>
+    selected: string | undefined
+    setCommunityId(string): void
+}
+
+export function CommunitySelector({
+    communities = [],
+    selected,
+    setCommunityId,
+}: CommunitySelectorProps) {
+    return (
+        <div className="CommunitySelector">
+            {communities.length > 0 && (
+                <select onChange={(e) => setCommunityId(e.target.value)} value={selected || ''}>
+                    {communities.map((community) => (
+                        <option value={community.id} key={community.id}>
+                            {community.name}
+                        </option>
+                    ))}
+                </select>
+            )}
+        </div>
+    )
+}

--- a/frontend/src/app/community/index.js
+++ b/frontend/src/app/community/index.js
@@ -1,1 +1,2 @@
 export * from './Join'
+export * from './Selector'

--- a/frontend/src/app/data/User.js
+++ b/frontend/src/app/data/User.js
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { getDatabase, onValue, ref, serverTimestamp, update } from 'firebase/database'
 
 import { DB_PATH } from '../constants'
+import { COMMUNITY_CONFIG } from '../../config/communities'
 import { fetchFromBackend } from '../utils'
 
 /*
@@ -103,4 +104,23 @@ export async function maybeUpdateUserDetails(details) {
         console.error(err)
         return err
     }
+}
+
+export function useUserCommunities(uid) {
+    const [communityId, setCommunityId] = useState()
+
+    // Fetch the user data to get the communities they are part of
+    const user = useGetManyUserData({ [uid]: true }, getUserData)?.[uid]
+    const communities = Object.keys(user?.communities || {}).map((k) => ({
+        ...COMMUNITY_CONFIG?.[k],
+        ...user?.communities?.[k],
+    }))
+
+    // Select the first active community
+    const firstActiveCommunity = communities.filter((c) => c.active)?.[0]?.id
+    useEffect(() => {
+        setCommunityId(firstActiveCommunity)
+    }, [firstActiveCommunity])
+
+    return [communityId, setCommunityId, communities]
 }

--- a/frontend/src/pages/EditProfilePage.jsx
+++ b/frontend/src/pages/EditProfilePage.jsx
@@ -1,28 +1,18 @@
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 import { Link } from 'react-router-dom'
 
 import { COMMUNITY_CONFIG } from '../config/communities'
 import { EditIntents, EditInterests } from '../app/attributes'
 import { CommunitySelector } from '../app/community'
-import { getUserData, useGetManyUserData } from '../app/data'
+import { useUserCommunities } from '../app/data'
 import { useCurrentAuthUser } from '../app/login'
 import { UserTile } from '../app/ui'
 
 export default function EditProfilePage() {
-    const [communityId, setCommunityId] = useState()
-    const communityConfig = COMMUNITY_CONFIG?.[communityId] || {}
-
     const authUser = useCurrentAuthUser()
     const uid = authUser?.uid
-    const user = useGetManyUserData({ [uid]: true }, getUserData)?.[uid]
-    const communities = Object.keys(user?.communities || {}).map((k) => ({
-        ...COMMUNITY_CONFIG?.[k],
-        ...user?.communities?.[k],
-    }))
-    const firstActiveCommunity = communities.filter((c) => c.active)?.[0]?.id
-    useEffect(() => {
-        setCommunityId(firstActiveCommunity)
-    }, [firstActiveCommunity])
+    const [communityId, setCommunityId, communities] = useUserCommunities(uid)
+    const communityConfig = COMMUNITY_CONFIG?.[communityId] || {}
 
     return (
         authUser && (


### PR DESCRIPTION
This will allow the edit profile page to use the correct community ID.

The `useUserCommunities()` hook can be used on other pages to get the communities that a user is part of and automatically update to their first active community when the data is fetched.