### PR TITLE
Pass keyword arguments for MatchingEngine subclasses.

### DIFF
--- a/pipeline/flows/matching.py
+++ b/pipeline/flows/matching.py
@@ -44,7 +44,7 @@ def compute_matches(inp: MatchingInput, engine_id: EngineId) -> List[Match]:
         msg = f"No engine found for ID: `{engine_id}`"
         logger.warning(msg)
         raise ValueError(msg)
-    engine: MatchingEngine = Engine()
+    engine: MatchingEngine = Engine(return_internal_data=True)
     logger.info(f"Running matching engine: `{engine_id}`")
     output = engine.run(inp)
     logger.info(f"Done. Output {len(output.matches)} matches.")

--- a/pipeline/matching/engines/main.py
+++ b/pipeline/matching/engines/main.py
@@ -23,7 +23,7 @@ ENGINE_MAIN = "mainEngine"
 
 
 class MainMatchingEngine(MatchingEngine):
-    def __init__(self):
+    def __init__(self, **kwargs):
         super().__init__(
             name=ENGINE_MAIN,
             generators=[
@@ -46,4 +46,5 @@ class MainMatchingEngine(MatchingEngine):
                 ]
             ),
             finalizer=FallbacksFinalizer(n_retries=10),
+            **kwargs
         )

--- a/pipeline/matching/engines/simple.py
+++ b/pipeline/matching/engines/simple.py
@@ -7,10 +7,11 @@ ENGINE_SIMPLE = "simpleEngine"
 
 
 class SimpleMatchingEngine(MatchingEngine):
-    def __init__(self):
+    def __init__(self, **kwargs):
         super().__init__(
             name=ENGINE_SIMPLE,
             generators=[CommonLettersGenerator(min_common=1)],
             ranker=CommonLettersRanker(),
             finalizer=FallbacksFinalizer(n_retries=5),
+            **kwargs
         )


### PR DESCRIPTION
@chunter3 this will fix your error in #255:

```
Unexpected keyword argument `return_internal_data`
```

The reason you get that error is because even though the `MatchingEngine` class has the `return_internal_data` keyword argument, its subclasses, like `MainMatchingEngine` do not.

To fix this, we add `**kwargs` to the constructor of the subclasses, and then pass those to the superclass constructor. This is a Python feature that allows you to pick up any extra keyword arguments and then pass those on.

Now, the `MainMatchingEngine` (and `SimpleMatchingEngine`) also support the `return_internal_data` keyword argument.