### PR TITLE
Skip invalid ratings records in extraction.

### DIFF
--- a/pipeline/extract/ratings.py
+++ b/pipeline/extract/ratings.py
@@ -1,5 +1,6 @@
 from typing import List
 
+import prefect
 from prefect import task
 
 from pipeline.types import Community, IntentUpvote, MatchStars
@@ -7,19 +8,24 @@ from pipeline.types import Community, IntentUpvote, MatchStars
 
 def extract_rating(db, community: Community, name: str, RatingSchema) -> List:
     """Helper function to extract rating records."""
+    logger = prefect.context.get("logger")
     ref = db.reference(f"ratings/{name}/{community}")
     raw = ref.get()
     if not raw:
         return []
     res = []
     for record in raw.values():
-        fields = {
-            **record,
-            "users": set(record.get("users", [])),
-            "community": community,
-        }
-        rating = RatingSchema(**fields)
-        res.append(rating)
+        try:
+            user_list = record.get("users", [])
+            fields = {
+                **record,
+                "users": set(user_list),
+                "community": community,
+            }
+            rating = RatingSchema(**fields)
+            res.append(rating)
+        except Exception as err:
+            logger.warning(f"Invalid {name} rating record:\n{err}\n{record}")
     return res
 
 

--- a/pipeline/extract/ratings_test.py
+++ b/pipeline/extract/ratings_test.py
@@ -14,7 +14,16 @@ def test_extract_match_stars():
             "users": ["A", "B"],
             "generator": "testGenerator",
             "timestamp": 1,
-        }
+        },
+        # Skip this invalid record, it has a list of a list for `users`
+        "2": {
+            "from_user": "A",
+            "value": 3,
+            "match": "aykl0021",
+            "users": [["A", "B"]],
+            "generator": "testGenerator",
+            "timestamp": 1,
+        },
     }
     mock_get_ratings = MagicMock(return_value=raw_ratings)
     mock_db = MagicMock()


### PR DESCRIPTION
Short-term solution for #274.

FYI @phodonou and @astep2023, the match stars data being saved to Firebase for some reason has a list of a list, rather than a list of user IDs. This causes the pipeline to fail, more details described in #274.

Not your fault at all! The real problem here is that we use the same Firebase database for testing and production :) so you would totally expect stuff like this to happen. See #144.

In the meantime, I have updated the pipeline code to be more resilient, if it finds invalid match rating records, it will skip them, then output the error message as a warning in the Prefect logs.

When you get a chance, please investigate why the ratings are saved incorrectly. Prince and I have permission to the delete the invalid records manually, which we can do after this is resolved.

## Example Output

```bash
Your branch is up to date with 'origin/vk_ratings_exception'.
(.venv) gitpod /workspace/butterfly (vk_ratings_exception) $ run flow matching
[2022-07-15 04:08:09+0000] INFO - prefect.FlowRunner | Beginning Flow run for 'matching_flow'
...
[2022-07-15 04:08:09+0000] INFO - prefect.TaskRunner | Task 'extract_match_stars': Starting task run...
[2022-07-15 04:08:09+0000] WARNING - prefect.extract_match_stars | Invalid match_stars rating record:
unhashable type: 'list'
{'community': 'demo', 'from_user': 'PX6eEHxnSXPHhPIqvbr5xyB9Peq2', 'generator': 'commonLettersGenerator', 'match': '2022-04-17~OTvRiBVI', 'timestamp': 1657843109030, 'users': [['PX6eEHxnSXPHhPIqvbr5xyB9Peq2', 'WTosWPSnmeQZkQ6UVMuvFmZeU5p1']], 'value': 1}
[2022-07-15 04:08:09+0000] WARNING - prefect.extract_match_stars | Invalid match_stars rating record:
unhashable type: 'list'
{'community': 'demo', 'from_user': 'PX6eEHxnSXPHhPIqvbr5xyB9Peq2', 'generator': 'commonLettersGenerator', 'match': '2022-04-17~OTvRiBVI', 'timestamp': 1657843191864, 'users': [['PX6eEHxnSXPHhPIqvbr5xyB9Peq2', 'WTosWPSnmeQZkQ6UVMuvFmZeU5p1']], 'value': 1}
...
[2022-07-15 04:08:09+0000] INFO - prefect.TaskRunner | Task 'extract_match_stars': Finished task run for task with final state: 'Success'
...
[2022-07-15 04:08:10+0000] INFO - prefect.FlowRunner | Flow run SUCCESS: all reference tasks succeeded
```