### PR TITLE
Add community ID to chat data.

### DIFF
--- a/frontend/src/app/chat/ChatApp.jsx
+++ b/frontend/src/app/chat/ChatApp.jsx
@@ -52,7 +52,8 @@ export function ChatAppInner({ chatId, header, conversation, composer }) {
 export function ChatApp({ chatId, header, conversation, composer }) {
     const authUser = useCurrentAuthUser()
     const myUserId = authUser?.uid
-    const chat = useGetChatData(`${chatId}~${myUserId}`)
+    const fullChatId = chatId && myUserId && `${chatId}~${myUserId}`
+    const chat = useGetChatData(fullChatId)
     const messages = useGetMessages(chatId)
 
     const sendChatMessage = (raw) => {

--- a/frontend/src/app/chat/ChatHooks.js
+++ b/frontend/src/app/chat/ChatHooks.js
@@ -22,7 +22,14 @@ export function useGetChatData(chatId) {
     const [data, setData] = useState({})
 
     useEffect(() => {
+        // Do not try to fetch if ID is nullish, return empty function from hook
+        if (!chatId) return () => undefined
         const db = getDatabase()
+        // TODO(vinesh): Clean up this hack. We are joining the community ID to
+        // the match ID to the user ID to get the user-match record. For now,
+        // this is an easy way to add community ID to the chat data response
+        // without adding it via a context or in the match dataclass.
+        const communityId = chatId.split('/')[0]
         const chatPath = `${DB_PATH.MATCHES}/${chatId}`
         const chatRef = ref(db, chatPath)
         // Fetch chat data
@@ -41,6 +48,7 @@ export function useGetChatData(chatId) {
             setData({
                 isLoaded: true,
                 exists: snap.exists(),
+                communityId,
                 ...val,
                 participants: participantData,
             })

--- a/frontend/src/app/types/ChatData.tsx
+++ b/frontend/src/app/types/ChatData.tsx
@@ -8,6 +8,8 @@ export interface ChatData {
     exists: boolean
     // Whether or not the chat has loaded
     isLoaded: boolean
+    // ID of the community this match is part of
+    communityId: string
     // ID of the user who this chat was created for, included in participants
     for: string
     // Map of the IDs of users in this chat (and match) to their user data


### PR DESCRIPTION
Fixes #272.

FYI @astep2023 @lacosta2 @phodonou you can now access the community ID that you need to submit ratings/upvotes from `chat.communityId`.