### PR TITLE
Add all user fields from database to User dataclass

### DIFF
--- a/pipeline/extract/users.py
+++ b/pipeline/extract/users.py
@@ -4,6 +4,11 @@ from prefect import task
 
 from pipeline.types import Community, UserCommunityMemberships
 
+USER_COLUMN_RENAMES = {
+    "latestLogin": "latest_login",
+    "photoURL": "photo_url",
+}
+
 
 def is_active_in_community(
     memberships: UserCommunityMemberships, community: Community
@@ -30,7 +35,9 @@ def extract_users(db, community: Community) -> pd.DataFrame:
     df_users = df_users[df_users.latestLogin.notna()]
     # Filter out users who are not active in the given community
     df_users = df_users[df_users.is_active]
-    # Drop columns used for internal filtering
-    df_users.drop(columns=["is_active", "communities"], inplace=True)
+    # Rename columns to snake case
+    df_users.rename(columns=USER_COLUMN_RENAMES, inplace=True)
+    # Cast latest login to integer
+    df_users.latest_login = df_users.latest_login.astype(int)
     logger.info("Returned {} rows, {} cols.".format(*df_users.shape))
     return df_users

--- a/pipeline/extract/users.py
+++ b/pipeline/extract/users.py
@@ -2,7 +2,7 @@ import pandas as pd
 import prefect
 from prefect import task
 
-from pipeline.types import Community, UserCommunityMemberships
+from pipeline.types import Community, RawUserCommunityMemberships
 
 USER_COLUMN_RENAMES = {
     "latestLogin": "latest_login",
@@ -11,7 +11,7 @@ USER_COLUMN_RENAMES = {
 
 
 def is_active_in_community(
-    memberships: UserCommunityMemberships, community: Community
+    memberships: RawUserCommunityMemberships, community: Community
 ) -> bool:
     """Checks for an active membership in the given community."""
     if not memberships:

--- a/pipeline/extract/users_test.py
+++ b/pipeline/extract/users_test.py
@@ -1,5 +1,7 @@
 from unittest.mock import MagicMock
 
+import numpy as np
+
 from pipeline.extract.users import extract_users
 
 
@@ -21,8 +23,12 @@ def test_extract_users_excludes_users_with_null_latest_login():
     # Verify that database was queried once with no parameters
     mock_get_users.assert_called_once_with()
 
-    # Verify that users with null latestLogin were filtered out
-    expected = [{"uid": "2", "latestLogin": 100}]
+    # Verify that users with null latest login were filtered out
+    expected_active_membership = {
+        "is_active": True,
+        "communities": {"test": {"active": True}},
+    }
+    expected = [{"uid": "2", "latest_login": 100, **expected_active_membership}]
     assert actual == expected
 
 
@@ -59,9 +65,62 @@ def test_extract_users_excludes_users_without_active_membership():
     mock_get_users.assert_called_once_with()
 
     # Verify that only users with active memberships in the community remain
+    expected_active_membership = {
+        "is_active": True,
+        "communities": {"test": {"active": True}},
+    }
+    expected_many_memberships = {
+        "is_active": True,
+        "communities": {
+            "something": {"active": True},
+            "test": {"active": True},
+        },
+    }
     expected = [
-        {"uid": "2", "latestLogin": 100},
-        {"uid": "6", "latestLogin": 100},
-        {"uid": "7", "latestLogin": 100},
+        {"uid": "2", "latest_login": 100, **expected_active_membership},
+        {"uid": "6", "latest_login": 100, **expected_active_membership},
+        {"uid": "7", "latest_login": 100, **expected_many_memberships},
+    ]
+    assert actual == expected
+
+
+def test_extract_users_renames_and_retains_fields():
+    active_membership = {
+        "latestLogin": 100,
+        "communities": {"test": {"active": True}},
+    }
+    users = {
+        "1": {"uid": "1", "photoURL": "meme.png", **active_membership},
+        "2": {"uid": "2", "somethingElse": "yo", **active_membership},
+    }
+    mock_get_users = MagicMock(return_value=users)
+    mock_db = MagicMock()
+    mock_db.reference("users").get = mock_get_users
+
+    actual_df = extract_users.run(mock_db, "test")
+    actual = actual_df.to_dict(orient="records")
+
+    mock_get_users.assert_called_once_with()
+
+    expected_active_membership = {
+        "latest_login": 100,
+        "is_active": True,
+        "communities": {"test": {"active": True}},
+    }
+    expected = [
+        # These fields get renamed because they are specified in the config
+        {
+            "uid": "1",
+            "photo_url": "meme.png",
+            "somethingElse": np.nan,
+            **expected_active_membership,
+        },
+        # These fields do not get renamed, but are still retained
+        {
+            "uid": "2",
+            "photo_url": np.nan,
+            "somethingElse": "yo",
+            **expected_active_membership,
+        },
     ]
     assert actual == expected

--- a/pipeline/transform/users.py
+++ b/pipeline/transform/users.py
@@ -4,12 +4,29 @@ from typing import List
 import pandas as pd
 from prefect import task
 
-from pipeline.types import User
+from pipeline.types import (
+    CommunityMembership,
+    RawUserCommunityMemberships,
+    User,
+    UserCommunityMemberships,
+)
+
+
+def parse_user_community_memberships(
+    raw: RawUserCommunityMemberships,
+) -> UserCommunityMemberships:
+    return {
+        community_id: CommunityMembership(**membership)
+        for community_id, membership in raw.items()
+    }
 
 
 @task
 def convert_users_from_df(df: pd.DataFrame) -> List[User]:
     cols = set(df.columns)
+    # Parse raw community membership records into dataclasses
+    if "communities" in df.columns:
+        df.communities = df.communities.apply(parse_user_community_memberships)
     field_names = [f.name for f in dataclasses.fields(User) if f.name in cols]
     user_dicts = df[field_names].to_dict(orient="records")
     return [User(**u) for u in user_dicts]

--- a/pipeline/transform/users_test.py
+++ b/pipeline/transform/users_test.py
@@ -1,7 +1,7 @@
 import pandas as pd
 
 from pipeline.transform.users import convert_users_from_df
-from pipeline.types import User
+from pipeline.types import CommunityMembership, User
 
 
 def test_convert_users_from_df():
@@ -15,5 +15,35 @@ def test_convert_users_from_df():
     expected = [
         User(uid="A", displayName="User A"),
         User(uid="B", displayName="User B"),
+    ]
+    assert actual == expected
+
+
+def test_convert_users_with_community_memberships_from_df():
+    df = pd.DataFrame(
+        [
+            {"uid": "A", "communities": {"a": {"active": True, "joined": 123}}},
+            {
+                "uid": "B",
+                "communities": {
+                    "a": {"active": True, "joined": 456},
+                    "b": {"active": False, "joined": 789},
+                },
+            },
+        ]
+    )
+    actual = convert_users_from_df.run(df)
+    expected = [
+        User(
+            uid="A",
+            communities={"a": CommunityMembership(active=True, joined=123)},
+        ),
+        User(
+            uid="B",
+            communities={
+                "a": CommunityMembership(active=True, joined=456),
+                "b": CommunityMembership(active=False, joined=789),
+            },
+        ),
     ]
     assert actual == expected

--- a/pipeline/types/community.py
+++ b/pipeline/types/community.py
@@ -1,3 +1,5 @@
+import datetime
+from dataclasses import dataclass
 from typing import Dict
 
 Community = str
@@ -5,6 +7,15 @@ Community = str
 # Dict with keys:
 # - active (boolean)
 # - joined (timestamp in ms)
-CommunityMembership = Dict
+RawCommunityMembership = Dict
+
+RawUserCommunityMemberships = Dict[Community, RawCommunityMembership]
+
+
+@dataclass
+class CommunityMembership:
+    active: bool
+    joined: datetime.datetime
+
 
 UserCommunityMemberships = Dict[Community, CommunityMembership]

--- a/pipeline/types/community.py
+++ b/pipeline/types/community.py
@@ -4,13 +4,6 @@ from typing import Dict
 
 Community = str
 
-# Dict with keys:
-# - active (boolean)
-# - joined (timestamp in ms)
-RawCommunityMembership = Dict
-
-RawUserCommunityMemberships = Dict[Community, RawCommunityMembership]
-
 
 @dataclass
 class CommunityMembership:

--- a/pipeline/types/raw_data.py
+++ b/pipeline/types/raw_data.py
@@ -1,8 +1,15 @@
 from typing import Dict
 
+from pipeline.types.community import Community
 from pipeline.types.intent import IntentCode, Side
 from pipeline.types.interest import InterestCode
 from pipeline.types.user import UserId
+
+# Dict with keys:
+# - active (boolean)
+# - joined (timestamp in ms)
+RawCommunityMembership = Dict
+RawUserCommunityMemberships = Dict[Community, RawCommunityMembership]
 
 # Two-level dictionary that indicates which interests a user selected
 RawUserInterests = Dict[UserId, Dict[InterestCode, bool]]

--- a/pipeline/types/user.py
+++ b/pipeline/types/user.py
@@ -1,6 +1,8 @@
+import datetime
 from dataclasses import dataclass, field
 from typing import List, Tuple
 
+from pipeline.types.community import UserCommunityMemberships
 from pipeline.types.intent import Intent
 from pipeline.types.interest import Interest
 from pipeline.types.schedule import Availability
@@ -12,7 +14,13 @@ UserGroup = Tuple[UserId, ...]
 @dataclass
 class User:
     uid: UserId
-    displayName: str
+    displayName: str = ""
+    email: str = ""
+    photo_url: str = ""
+    communities: UserCommunityMemberships = field(default_factory=dict)
+    latest_login: datetime.datetime = field(
+        default_factory=lambda: datetime.datetime.fromtimestamp(0)
+    )
     interests: List[Interest] = field(default_factory=list)
     intents: List[Intent] = field(default_factory=list)
     schedule: List[Availability] = field(default_factory=list)


### PR DESCRIPTION
This will unblock work on the notifications pipeline by giving us the user's email.

- [x] Add remaining database fields to `User` dataclass
  - Email, photo URL, latest login, and community memberships
- [x] Update extract code to rename columns from camel case to snake case
- [x] Update extract unit tests so that the `is_active` and `communities` columns are no longer dropped
- [x] Update extract unit tests to test that specified columns are renamed
- [x] Update extract unit tests to test that all columns from database are retained in DataFrame
- [x] Update extract unit tests to use `np.nan` for missing values
- [x] Update extract unit tests to use `RawCommunityMembership`
- [x] Move raw community membership types to be with other raw types
- [x] Update transform code to save community memberships as a dataclass
- [x] Update transform unit tests to verify community memberships
- [x] Test by running the matching flow for all communities