### PR TITLE
Fixed matching flow exception

### DIFF
--- a/notebooks/dfg-13/notebook.ipynb
+++ b/notebooks/dfg-13/notebook.ipynb
@@ -2,23 +2,9 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "ValueError",
-     "evalue": "The default Firebase app already exists. This means you called initialize_app() more than once without providing an app name as the second argument. In most cases you only need to call initialize_app() once. But if you do want to initialize multiple apps, pass a second argument to initialize_app() to give each app a unique name.",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
-      "\u001b[1;32m/workspace/butterfly/notebooks/dfg-13/notebook.ipynb Cell 1'\u001b[0m in \u001b[0;36m<cell line: 21>\u001b[0;34m()\u001b[0m\n\u001b[1;32m     <a href='vscode-notebook-cell://scarletstudio-butterfly-gnzrxfnj7jf.ws-us47.gitpod.io/workspace/butterfly/notebooks/dfg-13/notebook.ipynb#ch0000000vscode-remote?line=9'>10</a>\u001b[0m \u001b[39mfrom\u001b[39;00m \u001b[39mpipeline\u001b[39;00m\u001b[39m.\u001b[39;00m\u001b[39mextract\u001b[39;00m \u001b[39mimport\u001b[39;00m (\n\u001b[1;32m     <a href='vscode-notebook-cell://scarletstudio-butterfly-gnzrxfnj7jf.ws-us47.gitpod.io/workspace/butterfly/notebooks/dfg-13/notebook.ipynb#ch0000000vscode-remote?line=10'>11</a>\u001b[0m     extract_intent_upvotes,\n\u001b[1;32m     <a href='vscode-notebook-cell://scarletstudio-butterfly-gnzrxfnj7jf.ws-us47.gitpod.io/workspace/butterfly/notebooks/dfg-13/notebook.ipynb#ch0000000vscode-remote?line=11'>12</a>\u001b[0m     extract_intents,\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m     <a href='vscode-notebook-cell://scarletstudio-butterfly-gnzrxfnj7jf.ws-us47.gitpod.io/workspace/butterfly/notebooks/dfg-13/notebook.ipynb#ch0000000vscode-remote?line=15'>16</a>\u001b[0m     extract_users,\n\u001b[1;32m     <a href='vscode-notebook-cell://scarletstudio-butterfly-gnzrxfnj7jf.ws-us47.gitpod.io/workspace/butterfly/notebooks/dfg-13/notebook.ipynb#ch0000000vscode-remote?line=16'>17</a>\u001b[0m )\n\u001b[1;32m     <a href='vscode-notebook-cell://scarletstudio-butterfly-gnzrxfnj7jf.ws-us47.gitpod.io/workspace/butterfly/notebooks/dfg-13/notebook.ipynb#ch0000000vscode-remote?line=18'>19</a>\u001b[0m \u001b[39mfrom\u001b[39;00m \u001b[39mpipeline\u001b[39;00m\u001b[39m.\u001b[39;00m\u001b[39mutils\u001b[39;00m\u001b[39m.\u001b[39;00m\u001b[39mfirebase\u001b[39;00m \u001b[39mimport\u001b[39;00m initialize_firebase_for_prefect\n\u001b[0;32m---> <a href='vscode-notebook-cell://scarletstudio-butterfly-gnzrxfnj7jf.ws-us47.gitpod.io/workspace/butterfly/notebooks/dfg-13/notebook.ipynb#ch0000000vscode-remote?line=20'>21</a>\u001b[0m db \u001b[39m=\u001b[39m initialize_firebase_for_prefect\u001b[39m.\u001b[39;49mrun(os\u001b[39m.\u001b[39;49menviron[\u001b[39m'\u001b[39;49m\u001b[39mVITE_firebase_databaseURL\u001b[39;49m\u001b[39m'\u001b[39;49m],os\u001b[39m.\u001b[39;49menviron[\u001b[39m'\u001b[39;49m\u001b[39mAPI_ADMIN_CREDENTIALS\u001b[39;49m\u001b[39m'\u001b[39;49m])\n",
-      "File \u001b[0;32m/workspace/butterfly/notebooks/dfg-13/../../pipeline/utils/firebase.py:34\u001b[0m, in \u001b[0;36minitialize_firebase_for_prefect\u001b[0;34m(database_url, admin_credentials)\u001b[0m\n\u001b[1;32m     32\u001b[0m \u001b[39m# Initialize Firebase Admin service account\u001b[39;00m\n\u001b[1;32m     33\u001b[0m cred \u001b[39m=\u001b[39m credentials\u001b[39m.\u001b[39mCertificate(credentials_outfile)\n\u001b[0;32m---> 34\u001b[0m firebase_admin\u001b[39m.\u001b[39;49minitialize_app(cred, {\u001b[39m\"\u001b[39;49m\u001b[39mdatabaseURL\u001b[39;49m\u001b[39m\"\u001b[39;49m: database_url})\n\u001b[1;32m     36\u001b[0m \u001b[39m# After initialization, delete raw credentials file\u001b[39;00m\n\u001b[1;32m     37\u001b[0m \u001b[39mif\u001b[39;00m os\u001b[39m.\u001b[39mpath\u001b[39m.\u001b[39mexists(credentials_outfile):\n",
-      "File \u001b[0;32m/workspace/butterfly/.venv/lib/python3.8/site-packages/firebase_admin/__init__.py:71\u001b[0m, in \u001b[0;36minitialize_app\u001b[0;34m(credential, options, name)\u001b[0m\n\u001b[1;32m     68\u001b[0m         \u001b[39mreturn\u001b[39;00m app\n\u001b[1;32m     70\u001b[0m \u001b[39mif\u001b[39;00m name \u001b[39m==\u001b[39m _DEFAULT_APP_NAME:\n\u001b[0;32m---> 71\u001b[0m     \u001b[39mraise\u001b[39;00m \u001b[39mValueError\u001b[39;00m((\n\u001b[1;32m     72\u001b[0m         \u001b[39m'\u001b[39m\u001b[39mThe default Firebase app already exists. This means you called \u001b[39m\u001b[39m'\u001b[39m\n\u001b[1;32m     73\u001b[0m         \u001b[39m'\u001b[39m\u001b[39minitialize_app() more than once without providing an app name as \u001b[39m\u001b[39m'\u001b[39m\n\u001b[1;32m     74\u001b[0m         \u001b[39m'\u001b[39m\u001b[39mthe second argument. In most cases you only need to call \u001b[39m\u001b[39m'\u001b[39m\n\u001b[1;32m     75\u001b[0m         \u001b[39m'\u001b[39m\u001b[39minitialize_app() once. But if you do want to initialize multiple \u001b[39m\u001b[39m'\u001b[39m\n\u001b[1;32m     76\u001b[0m         \u001b[39m'\u001b[39m\u001b[39mapps, pass a second argument to initialize_app() to give each app \u001b[39m\u001b[39m'\u001b[39m\n\u001b[1;32m     77\u001b[0m         \u001b[39m'\u001b[39m\u001b[39ma unique name.\u001b[39m\u001b[39m'\u001b[39m))\n\u001b[1;32m     79\u001b[0m \u001b[39mraise\u001b[39;00m \u001b[39mValueError\u001b[39;00m((\n\u001b[1;32m     80\u001b[0m     \u001b[39m'\u001b[39m\u001b[39mFirebase app named \u001b[39m\u001b[39m\"\u001b[39m\u001b[39m{0}\u001b[39;00m\u001b[39m\"\u001b[39m\u001b[39m already exists. This means you called \u001b[39m\u001b[39m'\u001b[39m\n\u001b[1;32m     81\u001b[0m     \u001b[39m'\u001b[39m\u001b[39minitialize_app() more than once with the same app name as the \u001b[39m\u001b[39m'\u001b[39m\n\u001b[1;32m     82\u001b[0m     \u001b[39m'\u001b[39m\u001b[39msecond argument. Make sure you provide a unique name every time \u001b[39m\u001b[39m'\u001b[39m\n\u001b[1;32m     83\u001b[0m     \u001b[39m'\u001b[39m\u001b[39myou call initialize_app().\u001b[39m\u001b[39m'\u001b[39m)\u001b[39m.\u001b[39mformat(name))\n",
-      "\u001b[0;31mValueError\u001b[0m: The default Firebase app already exists. This means you called initialize_app() more than once without providing an app name as the second argument. In most cases you only need to call initialize_app() once. But if you do want to initialize multiple apps, pass a second argument to initialize_app() to give each app a unique name."
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import sys\n",
     "import os\n",
@@ -45,17 +31,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[2022-07-02 02:12:56+0000] INFO - prefect | Returned 6 rows, 5 cols.\n",
-      "[2022-07-02 02:12:56+0000] INFO - prefect | Extracted 20 user-match records.\n",
-      "[2022-07-02 02:12:56+0000] INFO - prefect | Converted to 9 match records.\n",
-      "[2022-07-02 02:12:56+0000] INFO - prefect | Returned 9 rows, 6 cols.\n"
+      "[2022-07-23 16:42:08+0000] INFO - prefect | Returned 6 rows, 5 cols.\n",
+      "[2022-07-23 16:42:08+0000] INFO - prefect | Extracted 20 user-match records.\n",
+      "[2022-07-23 16:42:08+0000] INFO - prefect | Converted to 9 match records.\n",
+      "[2022-07-23 16:42:08+0000] INFO - prefect | Returned 9 rows, 6 cols.\n"
      ]
     }
    ],
@@ -66,7 +52,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -87,16 +73,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "MatchMetadata(generator='blueGenerator', score=0, commonLetters=[], commonInterests=[], rareInterests=[], matchingIntents=[], rareIntents=[], matchingAvailability=[], limitedAvailability=[])"
+       "MatchMetadata(generator='blueGenerator', score=0, commonLetters=[], interests=[], intents=[], availability=[], commonInterests=[], rareInterests=[], matchingIntents=[], rareIntents=[], matchingAvailability=[], limitedAvailability=[])"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -107,16 +93,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "MatchMetadata(generator='greenGenerator', score=0, commonLetters=[], commonInterests=[], rareInterests=[], matchingIntents=[], rareIntents=[], matchingAvailability=[], limitedAvailability=[])"
+       "MatchMetadata(generator='greenGenerator', score=0, commonLetters=[], interests=[], intents=[], availability=[], commonInterests=[], rareInterests=[], matchingIntents=[], rareIntents=[], matchingAvailability=[], limitedAvailability=[])"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -127,16 +113,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[Match(users={'A', 'B'}, metadata=MatchMetadata(generator='blueGenerator', score=0, commonLetters=[], commonInterests=[], rareInterests=[], matchingIntents=[], rareIntents=[], matchingAvailability=[], limitedAvailability=[]), community=None, release=None, key=None, title=None)]"
+       "[Match(users={'B', 'A'}, metadata=MatchMetadata(generator='blueGenerator', score=0, commonLetters=[], interests=[], intents=[], availability=[], commonInterests=[], rareInterests=[], matchingIntents=[], rareIntents=[], matchingAvailability=[], limitedAvailability=[]), community=None, release=None, key=None, title=None)]"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -147,7 +133,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 80,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -201,18 +187,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 84,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "[IntentUpvote(from_user='D', to_user='B', value=1, intent='tutoring', community='test', match='1', users={'B', 'D'}, generator='blueGenerator')]"
-      ]
-     },
-     "execution_count": 84,
-     "metadata": {},
-     "output_type": "execute_result"
+     "ename": "NameError",
+     "evalue": "name 'intent_upvotes' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[1;32m/workspace/butterfly/notebooks/dfg-13/notebook.ipynb Cell 8\u001b[0m in \u001b[0;36m<cell line: 1>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> <a href='vscode-notebook-cell://scarletstudio-butterfly-gnzrxfnj7jf.ws-us54.gitpod.io/workspace/butterfly/notebooks/dfg-13/notebook.ipynb#ch0000007vscode-remote?line=0'>1</a>\u001b[0m intent_upvotes\n",
+      "\u001b[0;31mNameError\u001b[0m: name 'intent_upvotes' is not defined"
+     ]
     }
    ],
    "source": [
@@ -221,7 +208,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 85,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -241,7 +228,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 88,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -257,6 +244,70 @@
    ],
    "source": [
     "MatchRankFunction"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import dataclasses\n",
+    "from typing import List\n",
+    "\n",
+    "import pandas as pd\n",
+    "import prefect\n",
+    "from prefect import task\n",
+    "\n",
+    "from pipeline.matching.utils import generate_keys\n",
+    "from pipeline.types import (\n",
+    "    Community,\n",
+    "    Match,\n",
+    "    MatchingInput,\n",
+    "    MatchMetadata,\n",
+    "    ReleaseTag,\n",
+    ")\n",
+    "\n",
+    "@task\n",
+    "def convert_matches_from_df(df: pd.DataFrame) -> List[Match]:\n",
+    "    cols = set(df.columns)\n",
+    "    field_names = [f.name for f in dataclasses.fields(Match) if f.name in cols]\n",
+    "    match_dicts = df[field_names].to_dict(orient=\"records\")\n",
+    "    matches = []\n",
+    "    for record in match_dicts:\n",
+    "        raw_metadata = record.get(\"metadata\", {})\n",
+    "        parsed_metadata = MatchMetadata(**raw_metadata)\n",
+    "        record.pop(\"metadata\", None)\n",
+    "        match = Match(**record, metadata=parsed_metadata)\n",
+    "        matches.append(match)\n",
+    "    return matches"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'actual' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[1;32m/workspace/butterfly/notebooks/dfg-13/notebook.ipynb Cell 12\u001b[0m in \u001b[0;36m<cell line: 7>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      <a href='vscode-notebook-cell://scarletstudio-butterfly-gnzrxfnj7jf.ws-us54.gitpod.io/workspace/butterfly/notebooks/dfg-13/notebook.ipynb#ch0000011vscode-remote?line=3'>4</a>\u001b[0m     expected \u001b[39m=\u001b[39m [Match(users\u001b[39m=\u001b[39m{\u001b[39m\"\u001b[39m\u001b[39mA\u001b[39m\u001b[39m\"\u001b[39m, \u001b[39m\"\u001b[39m\u001b[39mB\u001b[39m\u001b[39m\"\u001b[39m})]\n\u001b[1;32m      <a href='vscode-notebook-cell://scarletstudio-butterfly-gnzrxfnj7jf.ws-us54.gitpod.io/workspace/butterfly/notebooks/dfg-13/notebook.ipynb#ch0000011vscode-remote?line=4'>5</a>\u001b[0m     \u001b[39massert\u001b[39;00m actual \u001b[39m==\u001b[39m expected\n\u001b[0;32m----> <a href='vscode-notebook-cell://scarletstudio-butterfly-gnzrxfnj7jf.ws-us54.gitpod.io/workspace/butterfly/notebooks/dfg-13/notebook.ipynb#ch0000011vscode-remote?line=6'>7</a>\u001b[0m actual\n",
+      "\u001b[0;31mNameError\u001b[0m: name 'actual' is not defined"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
+    "def test_convert_matches_from_df():\n",
+    "    df = pd.DataFrame([{\"users\": {\"A\", \"B\"}, \"extraData\": \"ignore\"}])\n",
+    "    actual = convert_matches_from_df.run(df)\n",
+    "    expected = [Match(users={\"A\", \"B\"})]\n",
+    "    assert actual == expected\n",
+    "\n"
    ]
   },
   {

--- a/pipeline/transform/matches.py
+++ b/pipeline/transform/matches.py
@@ -30,7 +30,6 @@ def convert_matches_from_df(df: pd.DataFrame) -> List[Match]:
     cols = set(df.columns)
     field_names = [f.name for f in dataclasses.fields(Match) if f.name in cols]
     match_dicts = df[field_names].to_dict(orient="records")
-    # matches = [Match(**u) for u in match_dicts]
     matches = []
     for record in match_dicts:
         raw_metadata = record.get("metadata", {})

--- a/pipeline/transform/matches.py
+++ b/pipeline/transform/matches.py
@@ -6,7 +6,13 @@ import prefect
 from prefect import task
 
 from pipeline.matching.utils import generate_keys
-from pipeline.types import Community, Match, MatchingInput, ReleaseTag
+from pipeline.types import (
+    Community,
+    Match,
+    MatchingInput,
+    MatchMetadata,
+    ReleaseTag,
+)
 
 
 class MissingReleaseTagException(Exception):
@@ -24,7 +30,10 @@ def convert_matches_from_df(df: pd.DataFrame) -> List[Match]:
     cols = set(df.columns)
     field_names = [f.name for f in dataclasses.fields(Match) if f.name in cols]
     user_dicts = df[field_names].to_dict(orient="records")
-    return [Match(**u) for u in user_dicts]
+    matches = [Match(**u) for u in user_dicts]
+    for match in matches:
+        match.metadata = MatchMetadata(str(match.metadata))
+    return matches
 
 
 @task

--- a/pipeline/transform/matches.py
+++ b/pipeline/transform/matches.py
@@ -29,10 +29,15 @@ def get_matching_input(**kwargs) -> MatchingInput:
 def convert_matches_from_df(df: pd.DataFrame) -> List[Match]:
     cols = set(df.columns)
     field_names = [f.name for f in dataclasses.fields(Match) if f.name in cols]
-    user_dicts = df[field_names].to_dict(orient="records")
-    matches = [Match(**u) for u in user_dicts]
-    for match in matches:
-        match.metadata = MatchMetadata(str(match.metadata))
+    match_dicts = df[field_names].to_dict(orient="records")
+    # matches = [Match(**u) for u in match_dicts]
+    matches = []
+    for record in match_dicts:
+        raw_metadata = record.get("metadata", {})
+        parsed_metadata = MatchMetadata(**raw_metadata)
+        record.pop("metadata", None)
+        match = Match(**record, metadata=parsed_metadata)
+        matches.append(match)
     return matches
 
 

--- a/pipeline/transform/matches_test.py
+++ b/pipeline/transform/matches_test.py
@@ -4,13 +4,15 @@ from pipeline.transform.matches import (
     convert_matches_from_df,
     filter_recent_matches,
 )
-from pipeline.types import Match
+from pipeline.types import Match, MatchMetadata
 
 
 def test_convert_matches_from_df():
     df = pd.DataFrame([{"users": {"A", "B"}, "extraData": "ignore"}])
     actual = convert_matches_from_df.run(df)
-    expected = [Match(users={"A", "B"})]
+    expected = [
+        Match(users={"A", "B"}, metadata=MatchMetadata(generator="blank"))
+    ]
     assert actual == expected
 
 

--- a/pipeline/transform/matches_test.py
+++ b/pipeline/transform/matches_test.py
@@ -7,11 +7,27 @@ from pipeline.transform.matches import (
 from pipeline.types import Match, MatchMetadata
 
 
-def test_convert_matches_from_df():
+def test_convert_matches_from_df():  # no metadata is passed
     df = pd.DataFrame([{"users": {"A", "B"}, "extraData": "ignore"}])
     actual = convert_matches_from_df.run(df)
     expected = [
         Match(users={"A", "B"}, metadata=MatchMetadata(generator="blank"))
+    ]
+    assert actual == expected
+
+
+def test_convert_matches_from_df_2():  # metadata is passed using the blue generator
+    df = pd.DataFrame([{"users": {"A", "B"}, "extraData": "ignore"}])
+    actual = convert_matches_from_df.run(df)
+    actual[
+        0
+    ].metadata.generator = (
+        "blueGenerator"  # used to change the generator from 'blank'
+    )
+    expected = [
+        Match(
+            users={"A", "B"}, metadata=MatchMetadata(generator="blueGenerator")
+        )
     ]
     assert actual == expected
 

--- a/pipeline/transform/matches_test.py
+++ b/pipeline/transform/matches_test.py
@@ -16,14 +16,11 @@ def test_convert_matches_from_df():  # no metadata is passed
     assert actual == expected
 
 
-def test_convert_matches_from_df_2():  # metadata is passed using the blue generator
-    df = pd.DataFrame([{"users": {"A", "B"}, "extraData": "ignore"}])
-    actual = convert_matches_from_df.run(df)
-    actual[
-        0
-    ].metadata.generator = (
-        "blueGenerator"  # used to change the generator from 'blank'
+def test_convert_matches_from_df_using_metadata():  # metadata is passed using the blue generator
+    df = pd.DataFrame(
+        [{"users": {"A", "B"}, "metadata": {"generator": "blueGenerator"}}]
     )
+    actual = convert_matches_from_df.run(df)
     expected = [
         Match(
             users={"A", "B"}, metadata=MatchMetadata(generator="blueGenerator")


### PR DESCRIPTION
#281 

The initial bug was that MatchMetadata was running into errors because there was no "get" function. This prompted a change in the variety.py file, more specifically, ```match.metadata.generator == recent.metadata.generator```. I later found it was an issue in the way matches were extracted. All the changes that were made worked, but mypy prevented me from committing.