### PR TITLE
Log analytics event for sending a chat message.

### DIFF
--- a/frontend/src/app/chat/ChatApp.jsx
+++ b/frontend/src/app/chat/ChatApp.jsx
@@ -60,8 +60,13 @@ export function ChatApp({ chatId, header, conversation, composer }) {
         const message = raw?.trim()
         if (!myUserId || !message) return
         sendMessage(chatId, {
+            // Data actually needed to send the message
             message,
             from: myUserId,
+            // Additional data forlogging analytics
+            community: chat?.communityId,
+            release: chat?.release_tag,
+            chat: chatId,
         })
     }
 

--- a/frontend/src/app/chat/ChatHooks.js
+++ b/frontend/src/app/chat/ChatHooks.js
@@ -10,6 +10,7 @@ import {
     ref,
     serverTimestamp,
 } from 'firebase/database'
+import { getAnalytics, logEvent } from 'firebase/analytics'
 import { MESSAGE_TYPE } from './ChatConstants'
 import { DB_PATH } from '../constants'
 import { getUserData } from '../data'
@@ -125,4 +126,10 @@ export async function sendMessage(chatId, data) {
     const messagesPath = `${DB_PATH.MESSAGES}/${chatId}`
     const messagesRef = ref(db, messagesPath)
     await push(messagesRef, messageValue)
+    const analytics = getAnalytics()
+    logEvent(analytics, 'send_chat_message', {
+        community: data?.community,
+        release: data?.release,
+        chat: data?.chat,
+    })
 }


### PR DESCRIPTION
## Summary

Log an analytics event with custom event data about the community, release, and chat ID.

The release data can help us find out if users are going back to chats from previous weeks.

We can add more of these in future PRs, just wanted to do a single one with custom events to make sure it works.

## Tested

I confirmed that the event is being logged using the Google Analytics Debug extension and in the Firebase Analytics dashboard:

<img width="1182" alt="Screen Shot 2022-07-21 at 3 59 51 PM" src="https://user-images.githubusercontent.com/11896652/180314546-2f07c2fd-1733-4e4a-a5c7-29803d42c020.png">

<img width="1142" alt="Screen Shot 2022-07-21 at 4 00 09 PM" src="https://user-images.githubusercontent.com/11896652/180314555-af85b8c7-9b08-4fd6-ab53-ae0450ac84eb.png">
