### PR TITLE
Update similar intents generator to use intents metadata field.

### DIFF
--- a/pipeline/matching/generators/similar_intents.py
+++ b/pipeline/matching/generators/similar_intents.py
@@ -69,21 +69,21 @@ class SimilarIntentsGenerator(MatchGenerator):
                         key = get_lookup(u.uid, oth.uid)
                         # checks if the users have been matched, prevents duplicates
                         if key in all_matches:
-                            # additional check if the users have NOT matched on this intent and appends it to the matchingIntents
+                            # additional check if the users have NOT matched on this intent and appends it to the intents
                             if (
                                 intent_match
-                                not in all_matches[key].metadata.matchingIntents
+                                not in all_matches[key].metadata.intents
                             ):
-                                all_matches[
-                                    key
-                                ].metadata.matchingIntents.append(intent_match)
+                                all_matches[key].metadata.intents.append(
+                                    intent_match
+                                )
                         else:
                             new_match = Match(
                                 users={u.uid, oth.uid},
                                 metadata=MatchMetadata(
                                     generator=GENERATOR_SIMILAR_INTENTS,
                                     score=1,
-                                    matchingIntents=[intent_match],
+                                    intents=[intent_match],
                                 ),
                             )
                             all_matches[key] = new_match

--- a/pipeline/matching/generators/similar_intents_test.py
+++ b/pipeline/matching/generators/similar_intents_test.py
@@ -38,7 +38,7 @@ def test_example():
             metadata=MatchMetadata(
                 generator="similarIntentsGenerator",
                 score=1,
-                matchingIntents=[expected_intent],
+                intents=[expected_intent],
             ),
         ),
     ]
@@ -81,7 +81,7 @@ def test_mult_intents_user():
             metadata=MatchMetadata(
                 generator="similarIntentsGenerator",
                 score=1,
-                matchingIntents=[expected_intent2],
+                intents=[expected_intent2],
             ),
         ),
     ]
@@ -158,7 +158,7 @@ def test_mult_match_intent():
             metadata=MatchMetadata(
                 generator="similarIntentsGenerator",
                 score=1,
-                matchingIntents=[expected_intent4, expected_intent5],
+                intents=[expected_intent4, expected_intent5],
             ),
         ),
         Match(
@@ -166,7 +166,7 @@ def test_mult_match_intent():
             metadata=MatchMetadata(
                 generator="similarIntentsGenerator",
                 score=1,
-                matchingIntents=[expected_intent7, expected_intent6],
+                intents=[expected_intent7, expected_intent6],
             ),
         ),
     ]


### PR DESCRIPTION
Congratulations @lwilliams717 your similar intents generator is the first generator to have matches go into production!

As part of #259 I have updated your generator to output the similar intents to the `match.metadata.intents` field instead of the old `matchingIntents`, which we will eventually deprecate.

FYI @arushirai1 as this could lead to merge conflicts in the future.