### PR TITLE
Kept the messages in the search bar

### DIFF
--- a/frontend/src/app/chatmenu/SearchMessages.css
+++ b/frontend/src/app/chatmenu/SearchMessages.css
@@ -12,7 +12,6 @@
 }
 
 .Search .Input {
-    position: relative;
     --input-width: calc(80% - var(--send-width));
     min-width: var(--input-width);
     border-top-left-radius: var(--chat-composer-radius);
@@ -31,6 +30,6 @@
 
 .Search .text-icon {
     position: absolute;
-    top: 0;
-    left: 0;
+    top: 120px;
+    left: 450px;
 }

--- a/frontend/src/app/chatmenu/SearchMessages.css
+++ b/frontend/src/app/chatmenu/SearchMessages.css
@@ -30,6 +30,7 @@
 
 .Search .text-icon {
     position: absolute;
+    cursor: pointer;
     top: 120px;
     left: 450px;
 }

--- a/frontend/src/app/chatmenu/SearchMessages.css
+++ b/frontend/src/app/chatmenu/SearchMessages.css
@@ -12,6 +12,7 @@
 }
 
 .Search .Input {
+    position: relative;
     --input-width: calc(80% - var(--send-width));
     min-width: var(--input-width);
     border-top-left-radius: var(--chat-composer-radius);
@@ -23,5 +24,13 @@
     width: var(--send-width);
     border-top-right-radius: var(--chat-composer-radius);
     border-bottom-right-radius: var(--chat-composer-radius);
+    border-top-left-radius: 0px;
+    border-bottom-left-radius: 0px;
     background-color: rgba(42, 222, 250, 1);
+}
+
+.Search .text-icon {
+    position: absolute;
+    top: 0;
+    left: 0;
 }

--- a/frontend/src/app/chatmenu/SearchMessages.css
+++ b/frontend/src/app/chatmenu/SearchMessages.css
@@ -1,5 +1,5 @@
-.Search .Input,
-.Search .ButtonSearch {
+.Input,
+.ButtonSearch {
     box-sizing: border-box;
     display: inline-block;
     vertical-align: top;
@@ -11,7 +11,7 @@
     outline-color: rgba(0, 0, 0, 0);
 }
 
-.Search .Input {
+.Input {
     --input-width: calc(80% - var(--send-width));
     min-width: var(--input-width);
     border-top-left-radius: var(--chat-composer-radius);
@@ -19,18 +19,19 @@
     padding: 1em;
 }
 
-.Search .ButtonSearch {
+.ButtonSearch {
     width: var(--send-width);
     border-top-right-radius: var(--chat-composer-radius);
     border-bottom-right-radius: var(--chat-composer-radius);
     border-top-left-radius: 0px;
     border-bottom-left-radius: 0px;
     background-color: rgba(42, 222, 250, 1);
+    margin-left: -10px;
 }
 
-.Search .text-icon {
-    position: absolute;
+.text-icon {
+    position: relative;
     cursor: pointer;
-    top: 120px;
-    left: 450px;
+    top: 35px;
+    right: 25px;
 }

--- a/frontend/src/app/chatmenu/SearchMessages.tsx
+++ b/frontend/src/app/chatmenu/SearchMessages.tsx
@@ -79,7 +79,7 @@ const SearchMessagesInner = ({ messages, chat }: SearchMessagesProps) => {
 
     // Creates the Seach bar and Button
     return (
-        <div className="Search">
+        <>
             <textarea
                 className="Input"
                 placeholder="Search Messages"
@@ -102,7 +102,7 @@ const SearchMessagesInner = ({ messages, chat }: SearchMessagesProps) => {
                     totalMessages={messages}
                 />
             </div>
-        </div>
+        </>
     )
 }
 

--- a/frontend/src/app/chatmenu/SearchMessages.tsx
+++ b/frontend/src/app/chatmenu/SearchMessages.tsx
@@ -39,8 +39,11 @@ const MessagesInner = ({ chat, filteredMessages, totalMessages }) => {
     )
 }
 
+function cleanText(value: string) {
+    return value?.toLowerCase().trim()
+}
 const SearchMessagesInner = ({ messages, chat }: SearchMessagesProps) => {
-    const [value, setValue] = useState<string>()
+    const [value, setValue] = useState<string>('')
     const [filteredMessages, setfilteredMessages] = useState<MessagesData[] | undefined>()
 
     const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
@@ -51,16 +54,12 @@ const SearchMessagesInner = ({ messages, chat }: SearchMessagesProps) => {
     const doSearch = () => {
         setfilteredMessages(
             messages?.filter((text) => {
-                const searchString: string = value ?? ''
+                const searchString: string = cleanText(value)
+                const messageText: string = cleanText(text.message)
 
-                return (
-                    text.message.toLowerCase().includes(searchString.toLowerCase()) && // Changes the message to lowercase
-                    searchString !== '' && // Checks for whitespaces
-                    searchString.trim()
-                )
+                return searchString !== '' && messageText?.includes(searchString)
             })
         )
-        setValue('')
     }
 
     const searchOnCtrlEnter = (e: {
@@ -87,6 +86,7 @@ const SearchMessagesInner = ({ messages, chat }: SearchMessagesProps) => {
                 value={value}
                 onChange={handleChange}
                 onKeyDown={searchOnCtrlEnter}
+                // Add icon
             />
             <button type="button" onClick={doSearch} className="ButtonSearch">
                 <FontAwesomeIcon icon={faMagnifyingGlass} />

--- a/frontend/src/app/chatmenu/SearchMessages.tsx
+++ b/frontend/src/app/chatmenu/SearchMessages.tsx
@@ -2,7 +2,7 @@
 import React, { useState } from 'react'
 import './SearchMessages.css'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons'
+import { faMagnifyingGlass, faXmark } from '@fortawesome/free-solid-svg-icons'
 import { ChatMenuPageProps, MessagesData } from './ChatMenuPage'
 import { Message } from '../chat/Message'
 import { ChatData } from '../types'
@@ -76,24 +76,21 @@ const SearchMessagesInner = ({ messages, chat }: SearchMessagesProps) => {
             doSearch()
         }
     }
-    /*
-    const clearSearch = () => {
-        return setValue('')
-    } */
 
     // Creates the Seach bar and Button
-    // This goes in between the span <i class="fa-duotone fa-circle-x icon" onClick={clearSearch}></i>
     return (
         <div className="Search">
-            {/* <span role="button" className="text-icon" onClick={clearSearch}>
-                X
-    </span> */}
             <textarea
                 className="Input"
                 placeholder="Search Messages"
                 value={value}
                 onChange={handleChange}
                 onKeyDown={searchOnCtrlEnter}
+            />
+            <FontAwesomeIcon
+                onClick={() => setValue('')}
+                icon={faXmark}
+                className={value === '' ? 'Hidden' : 'text-icon'}
             />
             <button type="button" onClick={doSearch} className="ButtonSearch">
                 <FontAwesomeIcon icon={faMagnifyingGlass} />

--- a/frontend/src/app/chatmenu/SearchMessages.tsx
+++ b/frontend/src/app/chatmenu/SearchMessages.tsx
@@ -76,17 +76,23 @@ const SearchMessagesInner = ({ messages, chat }: SearchMessagesProps) => {
             doSearch()
         }
     }
+    /*
+    const clearSearch = () => {
+        return setValue('')
+    }
+    */
 
     // Creates the Seach bar and Button
+    // This goes in between the span <i class="fa-duotone fa-circle-x icon" onClick={clearSearch}></i>
     return (
         <div className="Search">
+            <span className="text-icon">X</span>
             <textarea
                 className="Input"
                 placeholder="Search Messages"
                 value={value}
                 onChange={handleChange}
                 onKeyDown={searchOnCtrlEnter}
-                // Add icon
             />
             <button type="button" onClick={doSearch} className="ButtonSearch">
                 <FontAwesomeIcon icon={faMagnifyingGlass} />

--- a/frontend/src/app/chatmenu/SearchMessages.tsx
+++ b/frontend/src/app/chatmenu/SearchMessages.tsx
@@ -79,14 +79,15 @@ const SearchMessagesInner = ({ messages, chat }: SearchMessagesProps) => {
     /*
     const clearSearch = () => {
         return setValue('')
-    }
-    */
+    } */
 
     // Creates the Seach bar and Button
     // This goes in between the span <i class="fa-duotone fa-circle-x icon" onClick={clearSearch}></i>
     return (
         <div className="Search">
-            <span className="text-icon">X</span>
+            {/* <span role="button" className="text-icon" onClick={clearSearch}>
+                X
+    </span> */}
             <textarea
                 className="Input"
                 placeholder="Search Messages"


### PR DESCRIPTION
Added the following enhancements to the Search Messages feature:

1. **Retain search term:** To avoid losing context about the search, retained the search term within the search `Textarea` element with a cross, an icon to clear out the previous search easily. 

2. **`cleanText` Helper function:** Added `cleanText(value)` in `frontend/src/app/chatmenu/SearchMessages.stories.tsx` file. This helper function addresses the following issues with the search term and messages being filtered:
- Returning `''` if there is no given value
- Converting search terms and messages to lower case
- Trimming whitespace


