### PR TITLE
Changes made to run matching pipeline for 2022-08-01 release.

### DIFF
--- a/pipeline/flows/config.py
+++ b/pipeline/flows/config.py
@@ -7,7 +7,7 @@ FLOWS = {
         "defaults": {
             "engine": "main",
             "community": "demo",
-            "release": "2022-08-01",
+            "release": "2022-08-08",
         },
     }
 }

--- a/pipeline/load/validation.py
+++ b/pipeline/load/validation.py
@@ -18,7 +18,8 @@ def validate_and_log_matches(
     names = {u.uid: u.displayName for u in users}
     for m in output_matches:
         match_names = ", ".join([names[uid] for uid in m.users])
-        logger.info(f"\t{match_names}")
+        generator = m.metadata.generator
+        logger.info(f"\t{match_names} ({generator})")
     try:
         total, t2, t3 = validate_matches(output_matches, users, recent_matches)
     except MatchValidationError as err:

--- a/pipeline/matching/generators/rare_intents.py
+++ b/pipeline/matching/generators/rare_intents.py
@@ -40,7 +40,7 @@ class RareIntentsGenerator(MatchGenerator):
         return percentDict
 
     def generate(self, inp: MatchingInput) -> Iterator[Match]:
-    
+
         # getting a percentage of rareness for every given
         percentDict = self.percentage(inp)
         # add all rare givers to this dictionary to later match them
@@ -82,7 +82,7 @@ class RareIntentsGenerator(MatchGenerator):
                                 },
                                 metadata=MatchMetadata(
                                     generator="rareIntentsGenerator",
-                                    rareIntents=[
+                                    intents=[
                                         IntentMatch(
                                             code=intents_in_community.code,
                                             seeker=users_in_community.uid,
@@ -113,7 +113,7 @@ class RareIntentsGenerator(MatchGenerator):
                                 checking_same_user == False
                             ):  # this is to make sure that we are not making a match between one user
                                 if key in matches:
-                                    matches[key].metadata.rareIntents.append(
+                                    matches[key].metadata.intents.append(
                                         IntentMatch(
                                             code=intents_in_community.code,
                                             seeker=users_in_community.uid,
@@ -148,7 +148,7 @@ class RareIntentsGenerator(MatchGenerator):
         #                         },
         #                         metadata=MatchMetadata(
         #                             generator="rareIntentsGenerator",
-        #                             rareIntents=[
+        #                             intents=[
         #                                 IntentMatch(
         #                                     code=intents_in_community.code,
         #                                     seeker=users_in_community.uid,
@@ -166,7 +166,7 @@ class RareIntentsGenerator(MatchGenerator):
         #                 #         },
         #                 #         metadata=MatchMetadata(
         #                 #             generator="rareIntentsGenerator",
-        #                 #             rareIntents=[
+        #                 #             intents=[
         #                 #                 IntentMatch(
         #                 #                     code=intents_in_community.code,
         #                 #                     seeker=users_in_community.uid,

--- a/pipeline/matching/generators/rare_intents.py
+++ b/pipeline/matching/generators/rare_intents.py
@@ -40,7 +40,6 @@ class RareIntentsGenerator(MatchGenerator):
         return percentDict
 
     def generate(self, inp: MatchingInput) -> Iterator[Match]:
-
         # getting a percentage of rareness for every given
         percentDict = self.percentage(inp)
         # add all rare givers to this dictionary to later match them

--- a/pipeline/matching/generators/rare_intents_test.py
+++ b/pipeline/matching/generators/rare_intents_test.py
@@ -47,7 +47,7 @@ def testOne():
             users={"1", "3"},
             metadata=MatchMetadata(
                 generator="rareIntentsGenerator",
-                rareIntents=[expected_intent],
+                intents=[expected_intent],
             ),
         ),
     ]
@@ -180,21 +180,21 @@ def testFour():  # testing multiple matches
             users={"1", "5"},
             metadata=MatchMetadata(
                 generator="rareIntentsGenerator",
-                rareIntents=[expected_intent2],
+                intents=[expected_intent2],
             ),
         ),
         Match(
             users={"3", "5"},
             metadata=MatchMetadata(
                 generator="rareIntentsGenerator",
-                rareIntents=[expected_intent3],
+                intents=[expected_intent3],
             ),
         ),
         Match(
             users={"2", "5"},
             metadata=MatchMetadata(
                 generator="rareIntentsGenerator",
-                rareIntents=[expected_intent1],
+                intents=[expected_intent1],
             ),
         ),
     ]
@@ -265,7 +265,7 @@ def testSix():  # match between two users over multiple intents
             users={"1", "2"},
             metadata=MatchMetadata(
                 generator="rareIntentsGenerator",
-                rareIntents=[expected_intent2, expected_intent1],
+                intents=[expected_intent2, expected_intent1],
             ),
         ),
     ]

--- a/pipeline/matching/generators/rare_interests.py
+++ b/pipeline/matching/generators/rare_interests.py
@@ -35,7 +35,7 @@ class RareInterestsGenerator(MatchGenerator):
                     metadata=MatchMetadata(
                         generator="rareInterestsGenerator",
                         score=round(rarityScore, 2),
-                        rareInterests=rareInterests_,
+                        interests=rareInterests_,
                     ),
                 )
             ]
@@ -85,7 +85,7 @@ class RareInterestsGenerator(MatchGenerator):
                 metadata=MatchMetadata(
                     generator="rareInterestsGenerator",
                     score=round(rarityScore, 2),
-                    rareInterests=rareInterests_,
+                    interests=rareInterests_,
                 ),
             )
         ]

--- a/pipeline/matching/generators/rare_interests_test.py
+++ b/pipeline/matching/generators/rare_interests_test.py
@@ -38,7 +38,7 @@ def test_single_rare_interest():
             metadata=MatchMetadata(
                 generator="rareInterestsGenerator",
                 score=0.4,
-                rareInterests=["reading"],
+                interests=["reading"],
             ),
         ),
     ]
@@ -73,7 +73,7 @@ def test_multiple_rare_interests():
             metadata=MatchMetadata(
                 generator="rareInterestsGenerator",
                 score=0.4,
-                rareInterests=["reading"],
+                interests=["reading"],
             ),
         ),
     ]
@@ -108,7 +108,7 @@ def test_equal_rare_intrests():
             metadata=MatchMetadata(
                 generator="rareInterestsGenerator",
                 score=0.25,
-                rareInterests=["hiking"],
+                interests=["hiking"],
             ),
         ),
     ]
@@ -143,7 +143,7 @@ def test_no_rare_intrests():
             metadata=MatchMetadata(
                 generator="rareInterestsGenerator",
                 score=0.0,
-                rareInterests=[],
+                interests=[],
             ),
         ),
     ]
@@ -168,7 +168,7 @@ def test_null_inputs():
             metadata=MatchMetadata(
                 generator="rareInterestsGenerator",
                 score=float(-1),
-                rareInterests=[],
+                interests=[],
             ),
         )
     ]

--- a/pipeline/matching/generators/similar_interests.py
+++ b/pipeline/matching/generators/similar_interests.py
@@ -8,7 +8,7 @@ GENERATOR_SIMILAR_INTERESTS = "similarInterestsGenerator"
 
 
 class SimilarInterestsGenerator(MatchGenerator):
-    def __init__(self, min_common: int = 0):
+    def __init__(self, min_common: int = 1):
         self.min_common = min_common
         super().__init__(name=GENERATOR_SIMILAR_INTERESTS)
 
@@ -39,6 +39,6 @@ class SimilarInterestsGenerator(MatchGenerator):
             metadata = MatchMetadata(
                 generator=GENERATOR_SIMILAR_INTERESTS,
                 score=calculate_score,
-                commonInterests=list(sorted(common_interest)),
+                interests=list(sorted(common_interest)),
             )
             yield Match(users={user_one.uid, user_two.uid}, metadata=metadata)

--- a/pipeline/matching/generators/similar_interests_test.py
+++ b/pipeline/matching/generators/similar_interests_test.py
@@ -37,7 +37,7 @@ def test_one_similar_interest():
             metadata=MatchMetadata(
                 generator="similarInterestsGenerator",
                 score=(1 / 3),
-                commonInterests=["swimming"],
+                interests=["swimming"],
             ),
         ),
     ]
@@ -100,7 +100,7 @@ def test_one_with_many_interest():
             metadata=MatchMetadata(
                 generator="similarInterestsGenerator",
                 score=(1 / 5),
-                commonInterests=["painting"],
+                interests=["painting"],
             ),
         ),
     ]


### PR DESCRIPTION
- [x] Display match generator alongside matches in `validate_and_log_matches()` task
- [x] Update similar interests generator to have parameter `min_common=1`, so that we do not generate matches for people with no common interests
- [x] Switch new interests and intents generators to use common metadata fields (#259)
- [x] Bump release to `2022-08-08` for next run