### PR TITLE
Add a placeholder for interests starters.

### DIFF
--- a/frontend/src/app/starters/InterestsStarter.tsx
+++ b/frontend/src/app/starters/InterestsStarter.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import './InterestsStarter.css'
 import { ConversationStarterProps } from './ConversationStarter'
 
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface InterestsStarterProps {
     // TODO: Fill out the props for your component
 }
@@ -9,11 +10,11 @@ interface InterestsStarterProps {
 // TODO: Implement your component
 // eslint-disable-next-line no-empty-pattern
 const InterestsStarterInner = ({}: InterestsStarterProps) => {
-    return <div />
+    return <p>You have some interests in common!</p>
 }
 
 // TODO: Pass your component its props
-// eslint-disable-next-line no-unused-vars
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const InterestsStarter = ({ chat }: ConversationStarterProps) => <InterestsStarterInner />
 
 export default InterestsStarter


### PR DESCRIPTION
FYI @Kawaiivee and @lortiz6 there are some interests matches this week, so I added this placeholder so that the conversation starter does not appear to be empty. Feel free to override it with whatever you want, you might get a small merge conflict.