### PR TITLE
Add URL info to analytics events collection.

### DIFF
--- a/backend/analytics/views/collect.py
+++ b/backend/analytics/views/collect.py
@@ -9,6 +9,8 @@ router = Router()
 
 class AnalyticsEvent(Schema):
     event_type: str
+    host: str
+    page_url: str
     data: Dict[str, Any]
 
 

--- a/backend/analytics/views/collect_test.py
+++ b/backend/analytics/views/collect_test.py
@@ -17,6 +17,8 @@ def test_update_invalid_attribute(mock_db):
     url = "/analytics/collect/"
     data = {
         "event_type": "page_view",
+        "host": "localhost",
+        "page_url": "/butterfly/me",
         "data": {
             "page_id": "edit_profile",
             "duration_ms": 2103,
@@ -27,6 +29,8 @@ def test_update_invalid_attribute(mock_db):
     # Verify that the request was successful and that the mock push occurred
     expected_event = {
         "event_type": "page_view",
+        "host": "localhost",
+        "page_url": "/butterfly/me",
         "data": {
             "page_id": "edit_profile",
             "duration_ms": 2103,

--- a/frontend/src/app/utils/Analytics.js
+++ b/frontend/src/app/utils/Analytics.js
@@ -1,3 +1,4 @@
+/* global document */
 import { fetchFromBackend } from './Fetch'
 
 export function saveEvent(eventType, data) {
@@ -5,8 +6,13 @@ export function saveEvent(eventType, data) {
         route: '/analytics/collect/',
         options: {
             method: 'POST',
-            // eslint-disable-next-line camelcase
-            body: JSON.stringify({ event_type: eventType, data }),
+            body: JSON.stringify({
+                // eslint-disable-next-line camelcase
+                event_type: eventType,
+                host: document.location.host,
+                page_url: document.location.pathname,
+                data,
+            }),
         },
     })
 }


### PR DESCRIPTION
Adds two new fields to every analytics event:
 - `host`, which can tell you which website the event was saved from, that way we can exclude testing data
 - `page_url`, which can tell you the URL of the page the event was saved from, without the host

FYI @arushirai1 and @lwilliams717 I wanted to merge this tonight so that you can have this info any in events collected tomorrow if/when users start checking out their new matches for the week!