### PR TITLE
Hide blocked user chats

### DIFF
--- a/frontend/src/app/inbox/ChatInbox.css
+++ b/frontend/src/app/inbox/ChatInbox.css
@@ -1,3 +1,14 @@
 .ChatInbox {
     margin-top: 5px;
 }
+.HiddenInbox {
+    background: var(--color-theme-contrast);
+    color: var(--color-text);
+    box-shadow: 0 0 5px 1px var(--color-theme-accent);
+    padding: 1.5em;
+    box-sizing: border-box;
+    display: flex;
+}
+.btn {
+    margin: 15px;
+}

--- a/frontend/src/app/inbox/ChatInbox.css
+++ b/frontend/src/app/inbox/ChatInbox.css
@@ -10,5 +10,6 @@
     display: flex;
 }
 .btn {
+    cursor: pointer;
     margin: 15px;
 }

--- a/frontend/src/app/inbox/ChatInbox.tsx
+++ b/frontend/src/app/inbox/ChatInbox.tsx
@@ -6,10 +6,9 @@ import { ChatData, UserData } from '../types'
 interface ChatInboxProps {
     chats: ChatData[]
     users: { [uid: string]: UserData }
-    blockedUsers: Record<string, never>
 }
 
-const ChatInbox = ({ chats, users, blockedUsers }: ChatInboxProps) => {
+const ChatInbox = ({ chats, users }: ChatInboxProps) => {
     const mostRecentFirst = (a, b) => b.release_timestamp - a.release_timestamp
     const sortedChats = chats.sort(mostRecentFirst)
 
@@ -24,14 +23,11 @@ const ChatInbox = ({ chats, users, blockedUsers }: ChatInboxProps) => {
             const com = c?.communityConfig || {}
             return <ChatPreview key={c.id} match={c} users={users} community={com} />
         })
-    // TODO: hide blocked users chat
 
     return (
         <div className="ChatInbox">
             {noChatsEl}
             {chatEls}
-            <div className="BlockInbox">block users here</div>
-            {Object.keys(blockedUsers)}
         </div>
     )
 }

--- a/frontend/src/app/inbox/ChatInbox.tsx
+++ b/frontend/src/app/inbox/ChatInbox.tsx
@@ -2,14 +2,14 @@ import React from 'react'
 import './ChatInbox.css'
 import ChatPreview from './ChatPreview'
 import { ChatData, UserData } from '../types'
-import { fetchFromBackend, useBackendFetchJson } from '../utils'
 
 interface ChatInboxProps {
     chats: ChatData[]
     users: { [uid: string]: UserData }
+    blockedUsers: Record<string, never>
 }
 
-const ChatInbox = ({ chats, users }: ChatInboxProps) => {
+const ChatInbox = ({ chats, users, blockedUsers }: ChatInboxProps) => {
     const mostRecentFirst = (a, b) => b.release_timestamp - a.release_timestamp
     const sortedChats = chats.sort(mostRecentFirst)
 
@@ -31,6 +31,7 @@ const ChatInbox = ({ chats, users }: ChatInboxProps) => {
             {noChatsEl}
             {chatEls}
             <div className="BlockInbox">block users here</div>
+            {Object.keys(blockedUsers)}
         </div>
     )
 }

--- a/frontend/src/app/inbox/ChatInbox.tsx
+++ b/frontend/src/app/inbox/ChatInbox.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import './ChatInbox.css'
 import ChatPreview from './ChatPreview'
 import { ChatData, UserData } from '../types'
+import { fetchFromBackend, useBackendFetchJson } from '../utils'
 
 interface ChatInboxProps {
     chats: ChatData[]
@@ -23,11 +24,13 @@ const ChatInbox = ({ chats, users }: ChatInboxProps) => {
             const com = c?.communityConfig || {}
             return <ChatPreview key={c.id} match={c} users={users} community={com} />
         })
+    // TODO: hide blocked users chat
 
     return (
         <div className="ChatInbox">
             {noChatsEl}
             {chatEls}
+            <div className="BlockInbox">block users here</div>
         </div>
     )
 }

--- a/frontend/src/pages/AllChatsPage.jsx
+++ b/frontend/src/pages/AllChatsPage.jsx
@@ -1,5 +1,8 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
+
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faChevronDown, faChevronUp } from '@fortawesome/free-solid-svg-icons'
 
 import { useCurrentAuthUser } from '../app/login'
 import { getUserData, useGetManyUserData, useGetAllUserMatches } from '../app/data'
@@ -45,6 +48,12 @@ export default function AllChatsPage() {
     const authUser = useCurrentAuthUser()
     const matches = useGetAllUserMatches(authUser?.uid)
     const blockedUsers = useFetchBlockedUsers(authUser?.uid)
+    const [isOpen, setIsOpen] = useState(false)
+
+    const handleInboxOpening = () => {
+        setIsOpen((prev) => !prev)
+    }
+
     // map to check if blocked user from dictionary is present in inbox
     const matchesWithBlocks = matches.map((match) => ({
         ...match,
@@ -78,10 +87,18 @@ export default function AllChatsPage() {
             <ChatInboxHeader />
             <ChatInbox chats={unblockedMatches} users={matchedUsers} />
 
-            {/* TODO: Make this a collapsable element */}
             <div className={blockedMatches.length === 0 ? 'Hidden' : ''}>
-                <h1>Hidden Conversations</h1>
-                <ChatInbox chats={blockedMatches} users={matchedUsers} />
+                <div className="Header Light">
+                    <h5>Hidden Conversations</h5>
+                    <button type="button" className="btn" onClick={handleInboxOpening}>
+                        {!isOpen ? (
+                            <FontAwesomeIcon icon={faChevronDown} />
+                        ) : (
+                            <FontAwesomeIcon icon={faChevronUp} />
+                        )}
+                    </button>
+                </div>
+                {isOpen && <ChatInbox chats={blockedMatches} users={matchedUsers} />}
             </div>
         </div>
     )

--- a/frontend/src/pages/AllChatsPage.jsx
+++ b/frontend/src/pages/AllChatsPage.jsx
@@ -46,18 +46,15 @@ export default function AllChatsPage() {
     const matches = useGetAllUserMatches(authUser?.uid)
     const blockedUsers = useFetchBlockedUsers(authUser?.uid)
 
-    const unblockedMatches = matches.filter(
-        (match) =>
-            !Object.keys(match.participants).some((participant) =>
-                Object.keys(blockedUsers).includes(participant)
-            )
-    )
+    const matchesWithBlocks = matches.map((match) => ({
+        ...match,
+        hasBlockedUser: Object.keys(match.participants).some(
+            (participant) => participant in blockedUsers
+        ),
+    }))
 
-    const blockedMatches = matches.filter((match) =>
-        Object.keys(match.participants).some((participant) =>
-            Object.keys(blockedUsers).includes(participant)
-        )
-    )
+    const unblockedMatches = matchesWithBlocks.filter((m) => !m.hasBlockedUser)
+    const blockedMatches = matchesWithBlocks.filter((m) => m.hasBlockedUser)
 
     const matchedUserIds = matches.reduce(
         (agg, m) => ({
@@ -81,9 +78,11 @@ export default function AllChatsPage() {
             <ChatInboxHeader />
             <ChatInbox chats={unblockedMatches} users={matchedUsers} />
 
-            {/* TODO: Make this a collapsable element & hide it if no blockedMatches are present */}
-            <h1>Hidden Conversations</h1>
-            <ChatInbox chats={blockedMatches} users={matchedUsers} />
+            {/* TODO: Make this a collapsable element */}
+            <div className={blockedMatches.length === 0 ? 'Hidden' : ''}>
+                <h1>Hidden Conversations</h1>
+                <ChatInbox chats={blockedMatches} users={matchedUsers} />
+            </div>
         </div>
     )
 }

--- a/frontend/src/pages/AllChatsPage.jsx
+++ b/frontend/src/pages/AllChatsPage.jsx
@@ -88,7 +88,7 @@ export default function AllChatsPage() {
             <ChatInbox chats={unblockedMatches} users={matchedUsers} />
 
             <div className={blockedMatches.length === 0 ? 'Hidden' : ''}>
-                <div className="Header Light">
+                <div className="HiddenInbox">
                     <h5>Hidden Conversations</h5>
                     <button type="button" className="btn" onClick={handleInboxOpening}>
                         {!isOpen ? (

--- a/frontend/src/pages/AllChatsPage.jsx
+++ b/frontend/src/pages/AllChatsPage.jsx
@@ -45,14 +45,14 @@ export default function AllChatsPage() {
     const authUser = useCurrentAuthUser()
     const matches = useGetAllUserMatches(authUser?.uid)
     const blockedUsers = useFetchBlockedUsers(authUser?.uid)
-
+    // map to check if blocked user from dictionary is present in inbox
     const matchesWithBlocks = matches.map((match) => ({
         ...match,
         hasBlockedUser: Object.keys(match.participants).some(
             (participant) => participant in blockedUsers
         ),
     }))
-
+    // separate blocked and unblocked chats
     const unblockedMatches = matchesWithBlocks.filter((m) => !m.hasBlockedUser)
     const blockedMatches = matchesWithBlocks.filter((m) => m.hasBlockedUser)
 


### PR DESCRIPTION
Added implementation to display a **Hidden Conversations** section on `AllChatsPage` to separate chats with blocked users. 
- Created a dictionary of blocked users and their `blocked` status. 
- Added additional `ChatInbox` to display chats with/without blocked user participants. 
- [x] Make the Hidden Conversations section a collapsible element. 
- [x] Show/Hide Hidden Conversations section based on if any chats include blocked user participants or not. 
