### PR TITLE
Do not send request if the valid condition is undefined.

### DIFF
--- a/frontend/src/app/utils/Fetch.js
+++ b/frontend/src/app/utils/Fetch.js
@@ -19,9 +19,10 @@ export async function fetchFromBackend({ route, options = {} }) {
  * deps: React state variables for hook to depend on
  * isValid: if true, send the request, otherwise, skip it
  */
-export function useRawFetchJson({ url, options = {}, deps = [], isValid = true }) {
+export function useRawFetchJson({ url, options = {}, deps = [], isValid }) {
     const [response, setResponse] = useState(null)
     const [error, setError] = useState(null)
+    const shouldGetData = isValid !== undefined && isValid !== null
     useEffect(() => {
         async function getData() {
             try {
@@ -32,7 +33,7 @@ export function useRawFetchJson({ url, options = {}, deps = [], isValid = true }
                 setError(err)
             }
         }
-        if (isValid) getData()
+        if (shouldGetData) getData()
     }, deps)
     return [response, error]
 }


### PR DESCRIPTION
Fixes #373.

The `isValid` parameter is responsible for determining whether or not we send the request, in case some of the values used in the route or request start out as default values that are not valid.

This PR fixes a bug where `isValid` is `undefined`, so it gets incorrectly replaced with the default value of `true`.

- [x] Test that this fixes the problem with the hidden chats on the all chats page.
- [x] Test that other pages that use this function still work as expected.