### PR TITLE
Response rate analytics 

### DIFF
--- a/pipeline/flows/analytics.py
+++ b/pipeline/flows/analytics.py
@@ -7,7 +7,10 @@ from prefect.tasks.core.constants import Constant
 from prefect.tasks.secrets import PrefectSecret
 
 from pipeline.extract.analytics import extract_analytics
-from pipeline.transform.analytics import filter_chat_community
+from pipeline.transform.analytics import (
+    filter_chat_community,
+    filter_chat_events,
+)
 from pipeline.transform.chat_analytics import compute_chat_analytics
 from pipeline.utils.firebase import initialize_firebase_for_prefect
 
@@ -29,7 +32,7 @@ def analytics_flow(defaults: Dict = {}) -> Flow:
         )
 
         events = extract_analytics(db)
-        all_chats = filter_chat_community(events, param_community)
-        percentage_sds = compute_chat_analytics(all_chats)
+        all_chats = filter_chat_events(events)
+        compute_chat_analytics(all_chats)
 
     return flow

--- a/pipeline/flows/analytics.py
+++ b/pipeline/flows/analytics.py
@@ -1,0 +1,35 @@
+from typing import Dict
+
+import pandas as pd
+import prefect
+from prefect import Flow, Parameter
+from prefect.tasks.core.constants import Constant
+from prefect.tasks.secrets import PrefectSecret
+
+from pipeline.extract.analytics import extract_analytics
+from pipeline.transform.analytics import filter_chat_community
+from pipeline.transform.chat_analytics import compute_chat_analytics
+from pipeline.utils.firebase import initialize_firebase_for_prefect
+
+
+def analytics_flow(defaults: Dict = {}) -> Flow:
+    with Flow(name="analytics_flow") as flow:
+        # logger = prefect.context.get("logger")
+        param_community = Parameter(
+            name="community",
+            default=defaults.get("community"),
+            required=True,
+        )
+
+        # Configure database connection
+        secret_database_url = PrefectSecret("database_url")
+        secret_admin_credentials = PrefectSecret("admin_credentials")
+        db = initialize_firebase_for_prefect(
+            secret_database_url, secret_admin_credentials
+        )
+
+        events = extract_analytics(db)
+        all_chats = filter_chat_community(events, param_community)
+        percentage_sds = compute_chat_analytics(all_chats)
+
+    return flow

--- a/pipeline/flows/config.py
+++ b/pipeline/flows/config.py
@@ -1,3 +1,4 @@
+from pipeline.flows.analytics import analytics_flow
 from pipeline.flows.matching import matching_flow
 from pipeline.flows.notifications import notifications_flow
 
@@ -14,5 +15,11 @@ FLOWS = {
     "notifications": {
         "flow": notifications_flow,
         "defaults": {"community": "demo"},
+    },
+    "analytics": {
+        "flow": analytics_flow,
+        "defaults": {
+            "community": "demo",
+        },
     },
 }

--- a/pipeline/flows/config.py
+++ b/pipeline/flows/config.py
@@ -18,8 +18,6 @@ FLOWS = {
     },
     "analytics": {
         "flow": analytics_flow,
-        "defaults": {
-            "community": "demo",
-        },
+        "defaults": {},
     },
 }

--- a/pipeline/transform/__init__.py
+++ b/pipeline/transform/__init__.py
@@ -1,3 +1,5 @@
+from pipeline.transform.analytics import *
+from pipeline.transform.chat_analytics import *
 from pipeline.transform.compute_metrics import *
 from pipeline.transform.matches import *
 from pipeline.transform.user_intents import *

--- a/pipeline/transform/analytics.py
+++ b/pipeline/transform/analytics.py
@@ -1,0 +1,20 @@
+from typing import List
+
+from prefect import task
+
+from pipeline.types import AnalyticsEvent
+
+
+@task
+def filter_chat_community(lst: List[AnalyticsEvent], community):
+    list_community = []
+    # wrong_data = []
+    for analytics_event in lst:
+        # breakpoint()
+        if "send_chat_message" == analytics_event.event_type:
+            if analytics_event.data.get("community") is None:
+                # wrong_data.append(analytics_event.data)
+                continue
+            elif community == analytics_event.data["community"]:
+                list_community.append(analytics_event.data)
+    return list_community

--- a/pipeline/transform/analytics.py
+++ b/pipeline/transform/analytics.py
@@ -5,16 +5,26 @@ from prefect import task
 from pipeline.types import AnalyticsEvent
 
 
+# task to filter chats based on community
 @task
 def filter_chat_community(lst: List[AnalyticsEvent], community):
     list_community = []
-    # wrong_data = []
     for analytics_event in lst:
-        # breakpoint()
         if "send_chat_message" == analytics_event.event_type:
             if analytics_event.data.get("community") is None:
-                # wrong_data.append(analytics_event.data)
                 continue
             elif community == analytics_event.data["community"]:
                 list_community.append(analytics_event.data)
     return list_community
+
+
+# task to filter data to only chat events
+@task
+def filter_chat_events(lst: List[AnalyticsEvent]):
+    chat_events = []
+    for analytics_event in lst:
+        if "send_chat_message" == analytics_event.event_type:
+            if analytics_event.data.get("community") == "demo":
+                continue
+            chat_events.append(analytics_event.data)
+    return chat_events

--- a/pipeline/transform/chat_analytics.py
+++ b/pipeline/transform/chat_analytics.py
@@ -6,35 +6,36 @@ from prefect import task
 from pipeline.types import AnalyticsEvent
 
 
+# task to calculate the percentage of users that are getting responses to their messages
 @task
 def compute_chat_analytics(all_chats):
-    # dictionary - the key is the match id and
-    # the value is the list of users that have chatted in that match
+    # dictionary - the key is the match id
+    # the value is the set of users that have chatted in that match
     chating_users_match: Dict[str, set] = {}
-    bad_data = []
-
     for chat in all_chats:
-        # breakpoint()
-        if "chat" not in chat or "user" not in chat:
-            bad_data.append(chat)
+        # checks if the data contains a chat id
+        if "chat" not in chat:
             continue
         chat_id = chat["chat"]
         user_id = chat["user"]
-        ind = chat_id.index("/") + 1
-        match_id = chat_id[ind:]
-
-        if match_id in chating_users_match:
-            chating_users_match[match_id].append(user_id)
+        if chat_id in chating_users_match:
+            chating_users_match[chat_id].add(user_id)
         else:
-            chating_users_match[match_id] = set(user_id)
+            chating_users_match[chat_id] = {user_id}
 
-    # number of chats with multiple chatting users
+    # calculates the number of chats with multiple chatting users
     chats_multiple_users = 0
     for key in chating_users_match:
         if len(chating_users_match[key]) > 1:
             chats_multiple_users = chats_multiple_users + 1
 
-    logger = prefect.context.get("logger")
+    # percentage of users that are responding to each other.
+    percentage_chatting = (
+        chats_multiple_users / len(chating_users_match)
+    ) * 100
 
-    # percentage of users that are responding to each other in any given community.
-    logger.info(chats_multiple_users / len(chating_users_match))
+    logger = prefect.context.get("logger")
+    string_formatted = "Chat Response Rate: {per:.2f}%".format(
+        per=percentage_chatting
+    )
+    logger.info(string_formatted)

--- a/pipeline/transform/chat_analytics.py
+++ b/pipeline/transform/chat_analytics.py
@@ -1,0 +1,40 @@
+from typing import Dict
+
+import prefect
+from prefect import task
+
+from pipeline.types import AnalyticsEvent
+
+
+@task
+def compute_chat_analytics(all_chats):
+    # dictionary - the key is the match id and
+    # the value is the list of users that have chatted in that match
+    chating_users_match: Dict[str, set] = {}
+    bad_data = []
+
+    for chat in all_chats:
+        # breakpoint()
+        if "chat" not in chat or "user" not in chat:
+            bad_data.append(chat)
+            continue
+        chat_id = chat["chat"]
+        user_id = chat["user"]
+        ind = chat_id.index("/") + 1
+        match_id = chat_id[ind:]
+
+        if match_id in chating_users_match:
+            chating_users_match[match_id].append(user_id)
+        else:
+            chating_users_match[match_id] = set(user_id)
+
+    # number of chats with multiple chatting users
+    chats_multiple_users = 0
+    for key in chating_users_match:
+        if len(chating_users_match[key]) > 1:
+            chats_multiple_users = chats_multiple_users + 1
+
+    logger = prefect.context.get("logger")
+
+    # percentage of users that are responding to each other in any given community.
+    logger.info(chats_multiple_users / len(chating_users_match))

--- a/pipeline/types/raw_data.py
+++ b/pipeline/types/raw_data.py
@@ -15,3 +15,4 @@ RawUserCommunityMemberships = Dict[Community, RawCommunityMembership]
 RawUserInterests = Dict[UserId, Dict[InterestCode, bool]]
 # Three-level dictionary that indicates which intents a user selected
 RawUserIntents = Dict[UserId, Dict[IntentCode, Dict[Side, bool]]]
+RawAnalytics = Dict


### PR DESCRIPTION
For clarity, the response rate is the percentage of users that have chatted with their match and received a response from at least one other user.

The data calculated includes all communities and not just one specific community. Therefore, there is no default community in the config file. 
Also, the data only includes the ESI and SDS community. The demo community was excluded from the calculation process since most of the demo community users are used for testing and not actual butterfly users chatting with one another.

Some of the data for the chat event does not contain a chat id, only a user id. That data was ignored in the calculation process.
